### PR TITLE
Fix phone number formatting: strip trunk prefix and prevent double + …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.worktrees/
+vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## [1.2.0] - 2026-02-26
+
+### Added
+- EPP poll queue processing cron task with Nominet notification parsing
+- Poll feature switch (`poll_enabled`) per account, defaults to off
+- Nominet EPP extensions: contact-nom-ext and std-notifications namespaces
+- Custom poll response class for parsing Nominet notification types (domain cancelled, released, registrar change, referral rejected/accepted, registrant transfer, data quality, domains suspended)
+- EPP connection caching to reuse sessions within a single request
+- Domain delete, contact delete, host update, and poll EPP operations
+- Contact validation for Nominet registrant fields (type, trading name, company number)
+- DNSSEC management (add/remove DS records)
+- IPS tag push (domain transfer to another registrar)
+
+### Fixed
+- Phone number formatting: strip trunk prefix and prevent double `+` prefix
+- Contact updates now use `eppUpdateContactRequest` instead of creating new contacts
+- EPP connection properly logs out on session teardown
+- Whois tab labels corrected for Nominet registrant model
+- Multiple bug fixes: wrong filename, broken contact updates, premature domain update
+
+## [1.1.0] - 2024-05-03
+
+### Added
+- Additional TLD support
+
+### Fixed
+- Phone number sanitisation (duplicate `+` signs, non-numeric characters)
+- Domain contact add/get methods
+- Various registration and whois tab errors
+
+## [1.0.0] - 2023-12-21
+
+### Added
+- Initial release with Nominet EPP integration
+- Domain registration, renewal, and transfer
+- Nameserver management
+- Contact (registrant) management
+- Admin and client service tabs

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.1.0",
+    "version": "1.2.0",
     "type": "registrar",
     "name": "Nominet.name",
     "description": "Nominet.description",

--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
         "row": "Nominet.module_row",
         "rows": "Nominet.module_row_plural",
         "group": "Nominet.module_group",
-        "row_key": "username"
+        "row_key": "display_name"
     },
     "package": {
         "name_key": "epp_code"

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.0",
+    "version": "1.2.1",
     "type": "registrar",
     "name": "Nominet.name",
     "description": "Nominet.description",

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "type": "registrar",
     "name": "Nominet.name",
     "description": "Nominet.description",

--- a/config/nominet.php
+++ b/config/nominet.php
@@ -73,6 +73,40 @@ Configure::set('Nominet.tag_fields', [
 
 // Contact fields
 Configure::set('Nominet.contact_fields', [
+    'org_name' => [
+        'label' => Language::_('Nominet.contact_fields.org_name', true),
+        'type' => 'text'
+    ],
+    'type' => [
+        'label' => Language::_('Nominet.contact_fields.type', true),
+        'type' => 'select',
+        'options' => [
+            'LTD' => 'UK Limited Company',
+            'PLC' => 'UK Public Limited Company',
+            'PTNR' => 'UK Partnership',
+            'STRA' => 'UK Sole Trader',
+            'LLP' => 'UK Limited Liability Partnership',
+            'IP' => 'UK Industrial/Provident Company',
+            'IND' => 'UK Individual',
+            'SCH' => 'UK School',
+            'RCHAR' => 'UK Registered Charity',
+            'GOV' => 'UK Government Body',
+            'CRC' => 'UK Corporation by Royal Charter',
+            'STAT' => 'UK Statutory Body',
+            'OTHER' => 'UK Other',
+            'FIND' => 'Non-UK Individual',
+            'FCORP' => 'Non-UK Corporation',
+            'FOTHER' => 'Non-UK Other',
+        ]
+    ],
+    'trad_name' => [
+        'label' => Language::_('Nominet.contact_fields.trad_name', true),
+        'type' => 'text'
+    ],
+    'co_no' => [
+        'label' => Language::_('Nominet.contact_fields.co_no', true),
+        'type' => 'text'
+    ],
     'email' => [
         'label' => Language::_('Nominet.contact_fields.email', true),
         'type' => 'text'
@@ -115,8 +149,8 @@ Configure::set('Nominet.contact_fields', [
 // DNSSEC options
 Configure::set('Nominet.dnssec_options', [
     'flags' => [
-        '256' => 'Key Signing Key (KSK)',
-        '257' => 'Zone Signing Key (ZSK)'
+        '256' => 'Zone Signing Key (ZSK)',
+        '257' => 'Key Signing Key (KSK)'
     ],
     'digest' => [
         '1' => 'SHA-1',

--- a/config/nominet.php
+++ b/config/nominet.php
@@ -153,26 +153,26 @@ Configure::set('Nominet.dnssec_options', [
         '257' => 'Key Signing Key (KSK)'
     ],
     'digest' => [
-        '1' => 'SHA-1',
-        '2' => 'SHA-256',
-        '3' => 'GOST R 34.11-94',
-        '4' => 'SHA-384'
+        '1' => '1 - SHA-1',
+        '2' => '2 - SHA-256',
+        '3' => '3 - GOST R 34.11-94',
+        '4' => '4 - SHA-384'
     ],
     'algorithms' => [
-        '1' => 'RSA/MD5',
-        '2' => 'Diffie-Hellman',
-        '3' => 'DSA/SHA-1',
-        '4' => 'Elliptic Curve',
-        '5' => 'RSA/SHA-1',
-        '6' => 'DSA-NSEC3-SHA1',
-        '7' => 'RSASHA1-NSEC3-SHA1',
-        '8' => 'RSA/SHA-256',
-        '10' => 'RSA/SHA-512',
-        '12' => 'ECC-GOST',
-        '13' => 'ECDSA Curve P-256 with SHA-256',
-        '14' => 'ECDSA Curve P-384 with SHA-384',
-        '252' => 'Indirect',
-        '253' => 'Private DNS',
-        '254' => 'Private OID'
+        '1' => '1 - RSA/MD5',
+        '2' => '2 - Diffie-Hellman',
+        '3' => '3 - DSA/SHA-1',
+        '4' => '4 - Elliptic Curve',
+        '5' => '5 - RSA/SHA-1',
+        '6' => '6 - DSA-NSEC3-SHA1',
+        '7' => '7 - RSASHA1-NSEC3-SHA1',
+        '8' => '8 - RSA/SHA-256',
+        '10' => '10 - RSA/SHA-512',
+        '12' => '12 - ECC-GOST',
+        '13' => '13 - ECDSA Curve P-256 with SHA-256',
+        '14' => '14 - ECDSA Curve P-384 with SHA-384',
+        '252' => '252 - Indirect',
+        '253' => '253 - Private DNS',
+        '254' => '254 - Private OID'
     ]
 ]);

--- a/docs/plans/2026-03-04-domain-pricing-design.md
+++ b/docs/plans/2026-03-04-domain-pricing-design.md
@@ -1,0 +1,56 @@
+# Domain Pricing Feature Design
+
+**Date:** 2026-03-04
+**Status:** Approved
+
+## Overview
+
+Implement `getTldPricing` / `getFilteredTldPricing` for the Nominet module so that
+Blesta's domain pricing sync can populate all TLD prices (1–10 years, all currencies)
+from a single cost price configured per module row.
+
+## Background
+
+Nominet charges a single annual registry fee that applies uniformly to all TLDs
+(`.uk`, `.co.uk`, `.org.uk`, etc.). The price for N years is simply `base_price × N`.
+Blesta's domain pricing feature calls `getFilteredTldPricing()` expecting:
+
+```
+[tld => [currency => [year => ['register' => price, 'transfer' => price, 'renew' => price]]]]
+```
+
+It then applies configurable markup and stores the result as package pricing.
+
+## Data Storage
+
+A `cost_price` meta field is added to the module row, stored alongside existing
+fields (username, password, testbed, poll_enabled). It holds a plain decimal string
+representing the per-year cost in GBP (e.g. `"7.50"`).
+
+No migration is needed for existing rows — `cost_price` defaults to `0` if absent,
+and `getFilteredTldPricing()` returns `[]` in that case.
+
+## Pricing Logic
+
+- **Base currency:** GBP (Nominet's billing currency)
+- **Currency conversion:** Blesta's `Currencies::convert()` model converts GBP to
+  each company-configured currency
+- **Years:** 1–10, price = `converted_price × years`
+- **Operations:** register = transfer = renew = same cost price (Nominet IPS tag
+  transfers carry no registry fee; Blesta applies its own per-operation markup)
+- **Filters:** `tlds`, `currencies`, `terms` filter arrays are respected
+- **No result:** returns `[]` when cost_price is unset or zero
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `nominet.php` | Add `cost_price` to `$meta_fields`, `getRowRules()`, and implement `getTldPricing()` / `getFilteredTldPricing()` |
+| `views/default/add_row.pdt` | Add cost price text input |
+| `views/default/edit_row.pdt` | Add cost price text input |
+| `language/en_us/nominet.php` | Add label and validation error strings |
+| `config.json` | Bump version to 1.2.2 |
+
+## Version
+
+Bump to **1.2.2** — new feature, no breaking changes, no data migration required.

--- a/docs/plans/2026-03-04-domain-pricing.md
+++ b/docs/plans/2026-03-04-domain-pricing.md
@@ -1,0 +1,272 @@
+# Domain Pricing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `cost_price` field to the module row and implement `getFilteredTldPricing()` so Blesta can sync domain prices for all Nominet TLDs across 1–10 years in all configured currencies.
+
+**Architecture:** `cost_price` (GBP decimal) is stored as module row meta. `getFilteredTldPricing()` reads it, uses Blesta's `Currencies::convert()` to produce prices in all currencies, and returns the standard pricing array for all 10 Nominet TLDs × 10 years × 3 operations.
+
+**Tech Stack:** PHP 7.4+, Blesta RegistrarModule, Blesta Currencies model (`$this->Currencies->convert()`), `Configure::get('Nominet.tlds')` for TLD list.
+
+---
+
+### Task 1: Add language strings
+
+**Files:**
+- Modify: `language/en_us/nominet.php`
+
+**Step 1: Add two strings after the `poll_enabled` line**
+
+In `language/en_us/nominet.php`, after:
+```php
+$lang['Nominet.!error.poll_enabled.format'] = 'Poll enabled must be "true" or "false".';
+```
+Add:
+```php
+$lang['Nominet.row_meta.cost_price'] = 'Cost Price (GBP)';
+$lang['Nominet.!error.cost_price.format'] = 'Cost price must be a valid non-negative number.';
+```
+
+**Step 2: Verify syntax**
+```bash
+php -l language/en_us/nominet.php
+```
+Expected: `No syntax errors detected`
+
+**Step 3: Commit**
+```bash
+git add language/en_us/nominet.php
+git commit --author="Jon Morby <jon@fxrm.com>" -m "Add cost_price language strings"
+```
+
+---
+
+### Task 2: Add cost_price to module row meta
+
+**Files:**
+- Modify: `nominet.php` — `addModuleRow()`, `editModuleRow()`, `getRowRules()`
+
+**Step 1: Add `cost_price` to `$meta_fields` in `addModuleRow()`**
+
+Find this line in `addModuleRow()`:
+```php
+$meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled'];
+```
+Change to:
+```php
+$meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled', 'cost_price'];
+```
+
+**Step 2: Add `cost_price` to `$meta_fields` in `editModuleRow()`**
+
+Same change in `editModuleRow()`:
+```php
+$meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled', 'cost_price'];
+```
+
+**Step 3: Add validation rule to `getRowRules()`**
+
+In `getRowRules()`, after the `poll_enabled` rule block (before the closing `]` of `$rules`):
+```php
+'cost_price' => [
+    'format' => [
+        'rule' => ['matches', '/^\d+(\.\d{1,4})?$/'],
+        'message' => Language::_('Nominet.!error.cost_price.format', true)
+    ]
+],
+```
+
+**Step 4: Verify syntax**
+```bash
+php -l nominet.php
+```
+Expected: `No syntax errors detected`
+
+**Step 5: Commit**
+```bash
+git add nominet.php
+git commit --author="Jon Morby <jon@fxrm.com>" -m "Add cost_price meta field to module row"
+```
+
+---
+
+### Task 3: Add cost_price input to add/edit row views
+
+**Files:**
+- Modify: `views/default/add_row.pdt`
+- Modify: `views/default/edit_row.pdt`
+
+**Step 1: Add field to `add_row.pdt`**
+
+After the `poll_enabled` `<li>` block in `add_row.pdt`, add:
+```php
+                    <li>
+                        <?php
+                        $this->Form->label($this->_('Nominet.row_meta.cost_price', true), 'cost_price');
+                        $this->Form->fieldText('cost_price', ($vars->cost_price ?? null), ['id' => 'cost_price', 'class' => 'block']);
+                        ?>
+                    </li>
+```
+
+**Step 2: Add same field to `edit_row.pdt`**
+
+Same block, after the `poll_enabled` `<li>` in `edit_row.pdt`.
+
+**Step 3: Commit**
+```bash
+git add views/default/add_row.pdt views/default/edit_row.pdt
+git commit --author="Jon Morby <jon@fxrm.com>" -m "Add cost_price input to add/edit row views"
+```
+
+---
+
+### Task 4: Implement getTldPricing and getFilteredTldPricing
+
+**Files:**
+- Modify: `nominet.php` — add two new public methods
+
+**Step 1: Add both methods**
+
+Find the end of `nominet.php` — locate the last method before the closing `}` of the class. Add these two methods just before the closing brace:
+
+```php
+    /**
+     * Get a list of the TLD prices
+     *
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @return array A list of all TLDs and their pricing
+     *    [tld => [currency => [year# => ['register' => price, 'transfer' => price, 'renew' => price]]]]
+     */
+    public function getTldPricing($module_row_id = null)
+    {
+        return $this->getFilteredTldPricing($module_row_id);
+    }
+
+    /**
+     * Get a filtered list of the TLD prices
+     *
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @param array $filters A list of criteria by which to filter fetched pricings including:
+     *  - tlds A list of tlds for which to fetch pricings
+     *  - currencies A list of currencies for which to fetch pricings
+     *  - terms A list of terms for which to fetch pricings
+     * @return array A list of all TLDs and their pricing
+     *    [tld => [currency => [year# => ['register' => price, 'transfer' => price, 'renew' => price]]]]
+     */
+    public function getFilteredTldPricing($module_row_id = null, $filters = [])
+    {
+        // Get cost_price from the specified row, or the first available row
+        if ($module_row_id !== null) {
+            $row = $this->getModuleRow($module_row_id);
+        } else {
+            $rows = $this->getModuleRows();
+            $row = $rows[0] ?? null;
+        }
+
+        $cost_price = (float) ($row->meta->cost_price ?? 0);
+
+        if ($cost_price <= 0) {
+            return [];
+        }
+
+        Loader::loadModels($this, ['Currencies']);
+
+        $tlds = Configure::get('Nominet.tlds');
+        $currencies = $this->Currencies->getAll(Configure::get('Blesta.company_id'));
+        $pricing = [];
+
+        foreach ($tlds as $tld) {
+            if (isset($filters['tlds']) && !in_array($tld, $filters['tlds'])) {
+                continue;
+            }
+
+            $pricing[$tld] = [];
+
+            foreach ($currencies as $currency) {
+                if (isset($filters['currencies']) && !in_array($currency->code, $filters['currencies'])) {
+                    continue;
+                }
+
+                $converted = $this->Currencies->convert(
+                    $cost_price,
+                    'GBP',
+                    $currency->code,
+                    Configure::get('Blesta.company_id')
+                );
+
+                $pricing[$tld][$currency->code] = [];
+
+                foreach (range(1, 10) as $years) {
+                    if (isset($filters['terms']) && !in_array($years, $filters['terms'])) {
+                        continue;
+                    }
+
+                    $pricing[$tld][$currency->code][$years] = [
+                        'register' => $converted * $years,
+                        'transfer' => $converted * $years,
+                        'renew'    => $converted * $years,
+                    ];
+                }
+            }
+        }
+
+        return $pricing;
+    }
+```
+
+**Step 2: Verify syntax**
+```bash
+php -l nominet.php
+```
+Expected: `No syntax errors detected`
+
+**Step 3: Commit**
+```bash
+git add nominet.php
+git commit --author="Jon Morby <jon@fxrm.com>" -m "Implement getTldPricing and getFilteredTldPricing"
+```
+
+---
+
+### Task 5: Bump version to 1.2.2
+
+**Files:**
+- Modify: `config.json`
+
+**Step 1: Update version**
+
+In `config.json`, change:
+```json
+"version": "1.2.1",
+```
+to:
+```json
+"version": "1.2.2",
+```
+
+**Step 2: Commit**
+```bash
+git add config.json
+git commit --author="Jon Morby <jon@fxrm.com>" -m "Bump version to 1.2.2"
+```
+
+---
+
+### Task 6: Push and verify
+
+**Step 1: Push**
+```bash
+git push
+```
+
+**Step 2: Manual verification in Blesta**
+
+1. In Blesta admin, go to **Settings > Modules > Nominet > Edit** on a module row
+2. Confirm the **Cost Price (GBP)** field appears below Poll Enabled
+3. Enter a price (e.g. `7.50`) and save — confirm no validation errors
+4. Go to **Domains > TLDs**, select a `.co.uk` TLD and run **Sync Prices**
+5. Confirm prices populate for all configured currencies at 1–10 year terms
+6. Check that the 2-year price is exactly double the 1-year price
+
+**Step 3: Edge case — zero price**
+- Leave cost_price blank on a row, confirm that `getFilteredTldPricing()` returns `[]` and Blesta doesn't error (it skips modules that return empty)

--- a/language/en_us/nominet.php
+++ b/language/en_us/nominet.php
@@ -55,6 +55,7 @@ $lang['Nominet.row_meta.username'] = 'Username';
 $lang['Nominet.row_meta.password'] = 'Password';
 $lang['Nominet.row_meta.secure'] = 'Use Secure Connection';
 $lang['Nominet.row_meta.sandbox'] = 'Sandbox';
+$lang['Nominet.row_meta.poll_enabled'] = 'Enable EPP Poll Queue Processing';
 
 
 // Errors
@@ -65,6 +66,14 @@ $lang['Nominet.!error.ns2.valid'] = 'Invalid Name Server 2';
 $lang['Nominet.!error.ns3.valid'] = 'Invalid Name Server 3';
 $lang['Nominet.!error.ns4.valid'] = 'Invalid Name Server 4';
 $lang['Nominet.!error.ns5.valid'] = 'Invalid Name Server 5';
+$lang['Nominet.!error.contact.first_name.empty'] = 'First name is required.';
+$lang['Nominet.!error.contact.last_name.empty'] = 'Last name is required.';
+$lang['Nominet.!error.contact.email.valid'] = 'A valid email address is required.';
+$lang['Nominet.!error.contact.phone.empty'] = 'Phone number is required.';
+$lang['Nominet.!error.contact.address1.empty'] = 'Address is required.';
+$lang['Nominet.!error.contact.city.empty'] = 'City is required.';
+$lang['Nominet.!error.contact.country.empty'] = 'Country is required.';
+$lang['Nominet.!error.poll_enabled.format'] = 'Poll enabled must be "true" or "false".';
 
 
 // Service info
@@ -107,13 +116,15 @@ $lang['Nominet.contact_fields.state'] = 'State';
 $lang['Nominet.contact_fields.zip'] = 'Zip Code';
 $lang['Nominet.contact_fields.country'] = 'Country';
 $lang['Nominet.contact_fields.phone'] = 'Phone';
+$lang['Nominet.contact_fields.org_name'] = 'Organization Name';
+$lang['Nominet.contact_fields.type'] = 'Registrant Type';
+$lang['Nominet.contact_fields.trad_name'] = 'Trading Name';
+$lang['Nominet.contact_fields.co_no'] = 'Company Number';
 
 
 // Contacts tab
 $lang['Nominet.tab_whois.title'] = 'Contacts';
-$lang['Nominet.tab_whois.section_admin'] = 'Administrative';
-$lang['Nominet.tab_whois.section_tech'] = 'Technical';
-$lang['Nominet.tab_whois.section_billing'] = 'Billing';
+$lang['Nominet.tab_whois.section_registrant'] = 'Registrant';
 $lang['Nominet.tab_whois.field_submit'] = 'Update Contacts';
 
 
@@ -153,10 +164,8 @@ $lang['Nominet.tab_settings.field_submit'] = 'Update Domain';
 
 // Client contacts tab
 $lang['Nominet.tab_client_whois.title'] = 'Contacts';
-$lang['Nominet.tab_client_whois.heading'] = 'Contacts';
-$lang['Nominet.tab_client_whois.section_admin'] = 'Administrative';
-$lang['Nominet.tab_client_whois.section_tech'] = 'Technical';
-$lang['Nominet.tab_client_whois.section_billing'] = 'Billing';
+$lang['Nominet.tab_client_whois.heading'] = 'Registrant Contact';
+$lang['Nominet.tab_client_whois.section_registrant'] = 'Registrant';
 $lang['Nominet.tab_client_whois.field_submit'] = 'Update Contacts';
 
 
@@ -192,3 +201,8 @@ $lang['Nominet.tab_client_settings.text_push_domain'] = 'Transfer (push) the dom
 $lang['Nominet.tab_client_settings.text_auth_code'] = 'Use this authorization code to transfer your domain to another provider.';
 $lang['Nominet.tab_client_settings.field_tag'] = 'IPS Tag';
 $lang['Nominet.tab_client_settings.field_submit'] = 'Update Domain';
+
+
+// Cron Tasks
+$lang['Nominet.getCronTasks.process_poll_name'] = 'Process Nominet Poll Queue';
+$lang['Nominet.getCronTasks.process_poll_desc'] = 'Retrieves and acknowledges pending messages from the Nominet EPP message queue.';

--- a/language/en_us/nominet.php
+++ b/language/en_us/nominet.php
@@ -56,6 +56,7 @@ $lang['Nominet.row_meta.password'] = 'Password';
 $lang['Nominet.row_meta.secure'] = 'Use Secure Connection';
 $lang['Nominet.row_meta.testbed'] = 'Testbed';
 $lang['Nominet.row_meta.poll_enabled'] = 'Enable EPP Poll Queue Processing';
+$lang['Nominet.row_meta.cost_price'] = 'Cost Price (GBP)';
 
 
 // Errors
@@ -74,6 +75,7 @@ $lang['Nominet.!error.contact.address1.empty'] = 'Address is required.';
 $lang['Nominet.!error.contact.city.empty'] = 'City is required.';
 $lang['Nominet.!error.contact.country.empty'] = 'Country is required.';
 $lang['Nominet.!error.poll_enabled.format'] = 'Poll enabled must be "true" or "false".';
+$lang['Nominet.!error.cost_price.format'] = 'Cost price must be a valid non-negative number.';
 
 
 // Service info

--- a/language/en_us/nominet.php
+++ b/language/en_us/nominet.php
@@ -54,7 +54,7 @@ $lang['Nominet.edit_row.edit_btn'] = 'Update Account';
 $lang['Nominet.row_meta.username'] = 'Username';
 $lang['Nominet.row_meta.password'] = 'Password';
 $lang['Nominet.row_meta.secure'] = 'Use Secure Connection';
-$lang['Nominet.row_meta.sandbox'] = 'Sandbox';
+$lang['Nominet.row_meta.testbed'] = 'Testbed';
 $lang['Nominet.row_meta.poll_enabled'] = 'Enable EPP Poll Queue Processing';
 
 

--- a/lib/epp_connection.php
+++ b/lib/epp_connection.php
@@ -18,5 +18,19 @@ class NominetEppConnection extends eppConnection
         parent::__construct($logging, $settingsfile);
 
         $this->enableDnssec();
+
+        // Nominet extensions (declared in login)
+        $this->addExtension('std-notifications', 'http://www.nominet.org.uk/epp/xml/std-notifications-1.2');
+        $this->addExtension('contact-nom-ext', 'http://www.nominet.org.uk/epp/xml/contact-nom-ext-1.0');
+
+        // Nominet notification data uses 1.0/1.1 namespace URIs in actual XML,
+        // register these for XPath resolution in poll responses
+        $this->xpathuri['http://www.nominet.org.uk/epp/xml/std-notifications-1.0'] = 'n';
+        $this->xpathuri['http://www.nominet.org.uk/epp/xml/std-notifications-1.1'] = 'n11';
+
+        // Map Nominet request classes to response classes
+        $this->addCommandResponse('NominetEppCreateContactRequest', 'Metaregistrar\\EPP\\eppCreateContactResponse');
+        $this->addCommandResponse('NominetEppUpdateContactRequest', 'Metaregistrar\\EPP\\eppUpdateResponse');
+        $this->addCommandResponse('Metaregistrar\\EPP\\eppPollRequest', 'NominetEppPollResponse');
     }
 }

--- a/lib/nominet_epp_create_contact_request.php
+++ b/lib/nominet_epp_create_contact_request.php
@@ -1,0 +1,59 @@
+<?php
+
+use Metaregistrar\EPP\eppCreateContactRequest;
+use Metaregistrar\EPP\eppContact;
+
+/**
+ * Nominet EPP Create Contact Request with contact-nom-ext extension
+ *
+ * Adds Nominet-specific extension fields (type, trad-name, co-no) to
+ * standard EPP contact:create requests.
+ *
+ * @see https://registrars.nominet.uk/uk-namespace/registration-and-domain-management/schemas-and-namespaces/
+ */
+class NominetEppCreateContactRequest extends eppCreateContactRequest
+{
+    const NAMESPACE_URI = 'http://www.nominet.org.uk/epp/xml/contact-nom-ext-1.0';
+
+    private $registrantType;
+    private $tradName;
+    private $companyNumber;
+
+    public function __construct(
+        eppContact $createinfo,
+        $registrantType = null,
+        $tradName = null,
+        $companyNumber = null
+    ) {
+        parent::__construct($createinfo);
+
+        $this->registrantType = $registrantType;
+        $this->tradName = $tradName;
+        $this->companyNumber = $companyNumber;
+
+        if ($registrantType || $tradName || $companyNumber) {
+            $this->addNominetExtension();
+        }
+
+        $this->addSessionId();
+    }
+
+    private function addNominetExtension()
+    {
+        $this->addExtension('xmlns:contact-ext', self::NAMESPACE_URI);
+
+        $create = $this->createElement('contact-ext:create');
+
+        if ($this->tradName) {
+            $create->appendChild($this->createElement('contact-ext:trad-name', $this->tradName));
+        }
+        if ($this->registrantType) {
+            $create->appendChild($this->createElement('contact-ext:type', $this->registrantType));
+        }
+        if ($this->companyNumber) {
+            $create->appendChild($this->createElement('contact-ext:co-no', $this->companyNumber));
+        }
+
+        $this->getExtension()->appendChild($create);
+    }
+}

--- a/lib/nominet_epp_poll_response.php
+++ b/lib/nominet_epp_poll_response.php
@@ -1,0 +1,441 @@
+<?php
+
+use Metaregistrar\EPP\eppPollResponse;
+
+/**
+ * Nominet EPP Poll Response
+ *
+ * Parses Nominet-specific poll notification messages using the
+ * std-notifications-1.0 and std-notifications-1.1 namespaces.
+ *
+ * @see https://registrars.nominet.uk/uk-namespace/registration-and-domain-management/registration-systems/epp/epp-notifications/
+ */
+class NominetEppPollResponse extends eppPollResponse
+{
+    // Nominet notification types (std-notifications-1.0)
+    const TYPE_DOMAIN_CANCELLED = 'cancData';
+    const TYPE_DOMAINS_RELEASED = 'relData';
+    const TYPE_REGISTRAR_CHANGE = 'rcData';
+    const TYPE_REFERRAL_REJECTED = 'domainFailData';
+    const TYPE_REGISTRANT_TRANSFER = 'trnData';
+
+    // Nominet notification types (std-notifications-1.1)
+    const TYPE_DATA_QUALITY = 'processData';
+    const TYPE_DOMAINS_SUSPENDED = 'suspData';
+
+    // Standard EPP types handled by parent
+    const TYPE_REFERRAL_ACCEPTED = 'creData';
+    const TYPE_ACCOUNT_CHANGE = 'contactInfData';
+
+    private $nominetMessageType = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Determine the Nominet notification type from the poll response
+     *
+     * @return string|null One of the TYPE_* constants, or null if not a Nominet notification
+     */
+    public function getNominetMessageType()
+    {
+        if ($this->nominetMessageType !== null) {
+            return $this->nominetMessageType;
+        }
+
+        $xpath = $this->xPath();
+
+        // Check std-notifications-1.0 types
+        $types_v10 = [
+            self::TYPE_DOMAIN_CANCELLED,
+            self::TYPE_DOMAINS_RELEASED,
+            self::TYPE_REGISTRAR_CHANGE,
+            self::TYPE_REFERRAL_REJECTED,
+            self::TYPE_REGISTRANT_TRANSFER,
+        ];
+        foreach ($types_v10 as $type) {
+            $result = $xpath->query('/epp:epp/epp:response/epp:resData/n:' . $type);
+            if (is_object($result) && $result->length > 0) {
+                $this->nominetMessageType = $type;
+                return $type;
+            }
+        }
+
+        // Check std-notifications-1.1 types
+        $types_v11 = [
+            self::TYPE_DATA_QUALITY,
+            self::TYPE_DOMAINS_SUSPENDED,
+        ];
+        foreach ($types_v11 as $type) {
+            $result = $xpath->query('/epp:epp/epp:response/epp:resData/n11:' . $type);
+            if (is_object($result) && $result->length > 0) {
+                $this->nominetMessageType = $type;
+                return $type;
+            }
+        }
+
+        // Check standard EPP types
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/domain:creData');
+        if (is_object($result) && $result->length > 0) {
+            $this->nominetMessageType = self::TYPE_REFERRAL_ACCEPTED;
+            return self::TYPE_REFERRAL_ACCEPTED;
+        }
+
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/contact:infData');
+        if (is_object($result) && $result->length > 0) {
+            $this->nominetMessageType = self::TYPE_ACCOUNT_CHANGE;
+            return self::TYPE_ACCOUNT_CHANGE;
+        }
+
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Domain Cancelled (cancData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the cancelled domain name
+     *
+     * @return string|null
+     */
+    public function getCancelledDomainName()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:cancData/n:domainName');
+    }
+
+    /**
+     * Get the originator of the cancellation
+     *
+     * @return string|null
+     */
+    public function getCancellationOriginator()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:cancData/n:orig');
+    }
+
+    // -------------------------------------------------------------------------
+    // Domains Released (relData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the account ID for released domains
+     *
+     * @return string|null
+     */
+    public function getReleasedAccountId()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:relData/n:accountId');
+    }
+
+    /**
+     * Check if the account was moved
+     *
+     * @return string|null "Y" if moved
+     */
+    public function getReleasedAccountMoved()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/n:relData/n:accountId/@moved');
+        if (is_object($result) && $result->length > 0) {
+            return $result->item(0)->nodeValue;
+        }
+        return null;
+    }
+
+    /**
+     * Get the originating registrar tag
+     *
+     * @return string|null
+     */
+    public function getReleasedFromTag()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:relData/n:from');
+    }
+
+    /**
+     * Get the destination registrar tag
+     *
+     * @return string|null
+     */
+    public function getReleasedToTag()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:relData/n:registrarTag');
+    }
+
+    /**
+     * Get the list of released domain names
+     *
+     * @return array
+     */
+    public function getReleasedDomainNames()
+    {
+        return $this->getDomainList('/epp:epp/epp:response/epp:resData/n:relData/n:domainListData/n:domainName');
+    }
+
+    // -------------------------------------------------------------------------
+    // Registrar Change (rcData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the originator of the registrar change
+     *
+     * @return string|null
+     */
+    public function getRegistrarChangeOriginator()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:rcData/n:orig');
+    }
+
+    /**
+     * Get the registrar tag for the change
+     *
+     * @return string|null
+     */
+    public function getRegistrarChangeTag()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:rcData/n:registrarTag');
+    }
+
+    /**
+     * Get the case ID for the registrar change authorization request
+     *
+     * @return string|null
+     */
+    public function getRegistrarChangeCaseId()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:rcData/n:caseId');
+    }
+
+    /**
+     * Get domain names from a registrar change notification
+     *
+     * @return array
+     */
+    public function getRegistrarChangeDomainNames()
+    {
+        $xpath = $this->xPath();
+        $domains = [];
+
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/n:rcData/n:domainListData/domain:infData/domain:name');
+        if (is_object($result) && $result->length > 0) {
+            foreach ($result as $node) {
+                $domains[] = $node->nodeValue;
+            }
+        }
+
+        return $domains;
+    }
+
+    // -------------------------------------------------------------------------
+    // Referral Rejected (domainFailData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the domain name that was rejected
+     *
+     * @return string|null
+     */
+    public function getRejectedDomainName()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:domainFailData/n:domainName');
+    }
+
+    /**
+     * Get the rejection reason
+     *
+     * @return string|null
+     */
+    public function getRejectionReason()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:domainFailData/n:reason');
+    }
+
+    // -------------------------------------------------------------------------
+    // Registrant Transfer (trnData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the originator of the registrant transfer
+     *
+     * @return string|null
+     */
+    public function getRegistrantTransferOriginator()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:trnData/n:orig');
+    }
+
+    /**
+     * Get the new account ID after registrant transfer
+     *
+     * @return string|null
+     */
+    public function getRegistrantTransferAccountId()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:trnData/n:accountId');
+    }
+
+    /**
+     * Get the old account ID before registrant transfer
+     *
+     * @return string|null
+     */
+    public function getRegistrantTransferOldAccountId()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n:trnData/n:oldAccountId');
+    }
+
+    /**
+     * Get the domain names affected by registrant transfer
+     *
+     * @return array
+     */
+    public function getRegistrantTransferDomainNames()
+    {
+        return $this->getDomainList('/epp:epp/epp:response/epp:resData/n:trnData/n:domainListData/n:domainName');
+    }
+
+    // -------------------------------------------------------------------------
+    // Data Quality (processData) - std-notifications-1.1
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the data quality process stage
+     *
+     * @return string|null e.g. "initial", "updated"
+     */
+    public function getDataQualityStage()
+    {
+        $xpath = $this->xPath();
+        $result = $xpath->query('/epp:epp/epp:response/epp:resData/n11:processData/@stage');
+        if (is_object($result) && $result->length > 0) {
+            return $result->item(0)->nodeValue;
+        }
+        return null;
+    }
+
+    /**
+     * Get the data quality process type
+     *
+     * @return string|null
+     */
+    public function getDataQualityProcessType()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n11:processData/n11:processType');
+    }
+
+    /**
+     * Get the suspension date from data quality notification
+     *
+     * @return string|null
+     */
+    public function getDataQualitySuspendDate()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n11:processData/n11:suspendDate');
+    }
+
+    /**
+     * Get the domain names affected by data quality process
+     *
+     * @return array
+     */
+    public function getDataQualityDomainNames()
+    {
+        return $this->getDomainList('/epp:epp/epp:response/epp:resData/n11:processData/n11:domainListData/n11:domainName');
+    }
+
+    // -------------------------------------------------------------------------
+    // Domains Suspended (suspData) - std-notifications-1.1
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the suspension reason
+     *
+     * @return string|null
+     */
+    public function getSuspensionReason()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n11:suspData/n11:reason');
+    }
+
+    /**
+     * Get the cancellation date for suspended domains
+     *
+     * @return string|null
+     */
+    public function getSuspensionCancelDate()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/n11:suspData/n11:cancelDate');
+    }
+
+    /**
+     * Get the domain names that were suspended
+     *
+     * @return array
+     */
+    public function getSuspendedDomainNames()
+    {
+        return $this->getDomainList('/epp:epp/epp:response/epp:resData/n11:suspData/n11:domainListData/n11:domainName');
+    }
+
+    // -------------------------------------------------------------------------
+    // Referral Accepted (standard domain:creData)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Get the domain name from a referral accepted notification
+     *
+     * @return string|null
+     */
+    public function getAcceptedDomainName()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:name');
+    }
+
+    /**
+     * Get the creation date from a referral accepted notification
+     *
+     * @return string|null
+     */
+    public function getAcceptedCreationDate()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:crDate');
+    }
+
+    /**
+     * Get the expiration date from a referral accepted notification
+     *
+     * @return string|null
+     */
+    public function getAcceptedExpirationDate()
+    {
+        return $this->queryPath('/epp:epp/epp:response/epp:resData/domain:creData/domain:exDate');
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Extract a list of domain names from an XPath query
+     *
+     * @param string $path The XPath expression
+     * @return array
+     */
+    private function getDomainList($path)
+    {
+        $xpath = $this->xPath();
+        $domains = [];
+
+        $result = $xpath->query($path);
+        if (is_object($result) && $result->length > 0) {
+            foreach ($result as $node) {
+                $domains[] = $node->nodeValue;
+            }
+        }
+
+        return $domains;
+    }
+}

--- a/lib/nominet_epp_update_contact_request.php
+++ b/lib/nominet_epp_update_contact_request.php
@@ -1,0 +1,63 @@
+<?php
+
+use Metaregistrar\EPP\eppUpdateContactRequest;
+use Metaregistrar\EPP\eppContactHandle;
+use Metaregistrar\EPP\eppContact;
+
+/**
+ * Nominet EPP Update Contact Request with contact-nom-ext extension
+ *
+ * Adds Nominet-specific extension fields (type, trad-name, co-no) to
+ * standard EPP contact:update requests.
+ *
+ * @see https://registrars.nominet.uk/uk-namespace/registration-and-domain-management/schemas-and-namespaces/
+ */
+class NominetEppUpdateContactRequest extends eppUpdateContactRequest
+{
+    const NAMESPACE_URI = 'http://www.nominet.org.uk/epp/xml/contact-nom-ext-1.0';
+
+    private $registrantType;
+    private $tradName;
+    private $companyNumber;
+
+    public function __construct(
+        eppContactHandle $objectname,
+        $addinfo = null,
+        $removeinfo = null,
+        $updateinfo = null,
+        $registrantType = null,
+        $tradName = null,
+        $companyNumber = null
+    ) {
+        parent::__construct($objectname, $addinfo, $removeinfo, $updateinfo);
+
+        $this->registrantType = $registrantType;
+        $this->tradName = $tradName;
+        $this->companyNumber = $companyNumber;
+
+        if ($registrantType || $tradName || $companyNumber) {
+            $this->addNominetExtension();
+        }
+
+        $this->addSessionId();
+    }
+
+    private function addNominetExtension()
+    {
+        $this->addExtension('xmlns:contact-ext', self::NAMESPACE_URI);
+
+        $update = $this->createElement('contact-ext:update');
+
+        if ($this->tradName) {
+            $update->appendChild($this->createElement('contact-ext:trad-name', $this->tradName));
+        }
+        if ($this->registrantType) {
+            $update->appendChild($this->createElement('contact-ext:type', $this->registrantType));
+        }
+        if ($this->companyNumber) {
+            $update->appendChild($this->createElement('contact-ext:co-no', $this->companyNumber));
+        }
+
+        $this->getExtension()->appendChild($update);
+    }
+}

--- a/nominet.php
+++ b/nominet.php
@@ -1171,11 +1171,6 @@ class Nominet extends RegistrarModule
             'tabSettings' => Language::_('Nominet.tab_settings.title', true)
         ];
 
-        // Check if DNS Management is enabled
-        if (!$this->featureServiceEnabled('dns_management', $service)) {
-            unset($tabs['tabDnssec']);
-        }
-
         // Determine if this service has access to the settings tab
         $service_fields = $this->serviceFieldsToObject($service->fields);
         $ips_tag = $service_fields->enable_tag ?? '0';
@@ -1212,11 +1207,6 @@ class Nominet extends RegistrarModule
             'tabClientDnssec' => Language::_('Nominet.tab_client_dnssec.title', true),
             'tabClientSettings' => Language::_('Nominet.tab_client_settings.title', true)
         ];
-
-        // Check if DNS Management is enabled
-        if (!$this->featureServiceEnabled('dns_management', $service)) {
-            unset($tabs['tabClientDnssec']);
-        }
 
         // Determine if this service has access to the settings tab
         $service_fields = $this->serviceFieldsToObject($service->fields);

--- a/nominet.php
+++ b/nominet.php
@@ -14,17 +14,16 @@ use Blesta\Core\Util\Validate\Server;
 class Nominet extends RegistrarModule
 {
     /**
+     * @var array Cached EPP connections keyed by username
+     */
+    private $api_connections = [];
+
+    /**
      * @var array An array containing the EPP servers for live and sandbox requests
      */
     private $endpoint = [
-        'live' => [
-            'secure' => ['server' => 'epp.nominet.org.uk', 'port' => 700],
-            'insecure' => ['server' => 'epp.nominet.org.uk', 'port' => 8700]
-        ],
-        'sandbox' => [
-            'secure' => ['server' => 'testbed-epp.nominet.org.uk', 'port' => 700],
-            'insecure' => ['server' => 'testbed-epp.nominet.org.uk', 'port' => 8700]
-        ]
+        'live' => ['server' => 'epp.nominet.org.uk', 'port' => 700],
+        'sandbox' => ['server' => 'testbed-epp.nominet.org.uk', 'port' => 700]
     ];
 
     /**
@@ -42,6 +41,109 @@ class Nominet extends RegistrarModule
         $this->loadConfig(dirname(__FILE__) . DS . 'config.json');
 
         Configure::load('nominet', dirname(__FILE__) . DS . 'config' . DS);
+    }
+
+    /**
+     * Performs any necessary bootstrapping actions on install.
+     */
+    public function install()
+    {
+        $this->addCronTasks($this->getCronTasks());
+    }
+
+    /**
+     * Performs migration of data from $current_version (the current installed version)
+     * to the given file set version.
+     *
+     * @param string $current_version The current installed version of this module
+     */
+    public function upgrade($current_version)
+    {
+        if (version_compare($this->getVersion(), $current_version, '>')) {
+            if (version_compare($current_version, '1.2.0', '<')) {
+                $this->addCronTasks($this->getCronTasks());
+            }
+        }
+    }
+
+    /**
+     * Performs any necessary cleanup actions when the module is uninstalled.
+     *
+     * @param int $module_id The ID of the module being uninstalled
+     * @param bool $last_instance True if this is the last instance of the module across companies
+     */
+    public function uninstall($module_id, $last_instance)
+    {
+        Loader::loadModels($this, ['CronTasks']);
+
+        $cron_tasks = $this->getCronTasks();
+
+        if ($last_instance) {
+            foreach ($cron_tasks as $task) {
+                $cron_task = $this->CronTasks->getByKey($task['key'], $task['dir'], $task['task_type']);
+                if ($cron_task) {
+                    $this->CronTasks->deleteTask($cron_task->id, $task['task_type'], $task['dir']);
+                }
+            }
+        }
+
+        foreach ($cron_tasks as $task) {
+            $cron_task_run = $this->CronTasks->getTaskRunByKey($task['key'], $task['dir'], false, $task['task_type']);
+            if ($cron_task_run) {
+                $this->CronTasks->deleteTaskRun($cron_task_run->task_run_id);
+            }
+        }
+    }
+
+    /**
+     * Runs the cron task identified by the given key.
+     *
+     * @param string $key The cron task key
+     * @return mixed The result of the cron task
+     */
+    public function cron($key)
+    {
+        if ($key === 'process_poll') {
+            return $this->processPollQueue();
+        }
+
+        return [];
+    }
+
+    /**
+     * Processes the Nominet poll queue for all module rows.
+     *
+     * @return array An array of log entry strings for the cron log
+     */
+    private function processPollQueue()
+    {
+        $logs = [];
+        $rows = $this->getModuleRows();
+
+        if (!is_array($rows)) {
+            return ['No module rows available for polling.'];
+        }
+
+        foreach ($rows as $row) {
+            if (($row->meta->poll_enabled ?? 'false') !== 'true') {
+                $logs[] = 'Polling disabled for account ' . ($row->meta->username ?? $row->id ?? '?') . ', skipping.';
+                continue;
+            }
+
+            if (empty($row->meta->username)) {
+                $logs[] = 'Skipping module row ' . ($row->id ?? '?') . ': no credentials configured.';
+                continue;
+            }
+
+            try {
+                $messages = $this->pollMessages($row->id);
+                $logs[] = 'Polled ' . count($messages) . ' message(s) for account ' . $row->meta->username;
+            } catch (Throwable $e) {
+                $logs[] = 'Error polling account ' . $row->meta->username . ': ' . $e->getMessage();
+            }
+        }
+
+        return $logs;
     }
 
     /**
@@ -86,7 +188,7 @@ class Nominet extends RegistrarModule
 
         if (!empty($vars)) {
             // Set unset checkboxes
-            $checkbox_fields = ['secure', 'sandbox'];
+            $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
 
             foreach ($checkbox_fields as $checkbox_field) {
                 if (!isset($vars[$checkbox_field])) {
@@ -122,7 +224,7 @@ class Nominet extends RegistrarModule
             $vars = $module_row->meta;
         } else {
             // Set unset checkboxes
-            $checkbox_fields = ['secure', 'sandbox'];
+            $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
 
             foreach ($checkbox_fields as $checkbox_field) {
                 if (!isset($vars[$checkbox_field])) {
@@ -149,11 +251,11 @@ class Nominet extends RegistrarModule
      */
     public function addModuleRow(array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'sandbox'];
+        $meta_fields = ['username', 'password', 'secure', 'sandbox', 'poll_enabled'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
-        $checkbox_fields = ['secure', 'sandbox'];
+        $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
 
         foreach ($checkbox_fields as $checkbox_field) {
             if (!isset($vars[$checkbox_field])) {
@@ -195,11 +297,11 @@ class Nominet extends RegistrarModule
      */
     public function editModuleRow($module_row, array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'sandbox'];
+        $meta_fields = ['username', 'password', 'secure', 'sandbox', 'poll_enabled'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
-        $checkbox_fields = ['secure', 'sandbox'];
+        $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
 
         foreach ($checkbox_fields as $checkbox_field) {
             if (!isset($vars[$checkbox_field])) {
@@ -269,6 +371,12 @@ class Nominet extends RegistrarModule
                 'format' => [
                     'rule' => ['in_array', ['true', 'false']],
                     'message' => Language::_('Nominet.!error.sandbox.format', true)
+                ]
+            ],
+            'poll_enabled' => [
+                'format' => [
+                    'rule' => ['in_array', ['true', 'false']],
+                    'message' => Language::_('Nominet.!error.poll_enabled.format', true)
                 ]
             ]
         ];
@@ -397,7 +505,7 @@ class Nominet extends RegistrarModule
      * @see Module::getModule()
      * @see Module::getModuleRow()
      */
-    public function addPackage(array $vars = null)
+    public function addPackage(?array $vars = null)
     {
         // Set rules to validate input data
         $this->Input->setRules($this->getPackageRules($vars));
@@ -438,7 +546,7 @@ class Nominet extends RegistrarModule
      * @see Module::getModule()
      * @see Module::getModuleRow()
      */
-    public function editPackage($package, array $vars = null)
+    public function editPackage($package, ?array $vars = null)
     {
         // Set rules to validate input data
         $this->Input->setRules($this->getPackageRules($vars));
@@ -589,12 +697,12 @@ class Nominet extends RegistrarModule
      */
     public function addService(
         $package,
-        array $vars = null,
+        ?array $vars = null,
         $parent_package = null,
         $parent_service = null,
         $status = 'pending'
     ) {
-        if (($row = $this->getModuleRow())) {
+        if (($row = $this->getModuleRowById($package->module_row ?? null))) {
 
             // Validate service
             $this->validateService($package, $vars);
@@ -623,6 +731,7 @@ class Nominet extends RegistrarModule
                 // Register domain
                 $params = [
                     'contact' => [
+                        'org_name' => $client->company ?? '',
                         'first_name' => $client->first_name ?? '',
                         'last_name' => $client->last_name ?? '',
                         'address1' => $client->address1 ?? '',
@@ -679,47 +788,33 @@ class Nominet extends RegistrarModule
      * @see Module::getModule()
      * @see Module::getModuleRow()
      */
-    public function editService($package, $service, array $vars = null, $parent_package = null, $parent_service = null)
+    public function editService($package, $service, ?array $vars = null, $parent_package = null, $parent_service = null)
     {
-        if (($row = $this->getModuleRow())) {
-            $service_fields = $this->serviceFieldsToObject($service->fields);
-
-            $this->validateService($package, $vars, true);
-            if ($this->Input->errors()) {
-                return;
-            }
-
-            // Format input
-            $vars = $this->getFieldsFromInput($vars, $package);
-
-            // Only update the service if 'use_module' is true
-            if ($vars['use_module'] == 'true') {
-                // Update nameservers
-                if (isset($vars['ns']) && is_array($vars['ns'])) {
-                    $this->setDomainNameservers($this->getServiceDomain($service), $row->id, $vars['ns']);
-                }
-            }
-        } else {
+        $row = $this->getModuleRowById($service->module_row_id ?? $package->module_row ?? null);
+        if (!$row) {
             $this->Input->setErrors(
                 ['module_row' => ['missing' => Language::_('Nominet.!error.module_row.missing', true)]]
             );
+            return;
         }
 
-        // Return all the service fields
-        $encrypted_fields = [];
-        $return = [];
-        $fields = ['domain', 'enable_tag'];
-        foreach ($fields as $field) {
-            if (isset($vars[$field]) || isset($service_fields[$field])) {
-                $return[] = [
-                    'key' => $field,
-                    'value' => $vars[$field] ?? $service_fields[$field],
-                    'encrypted' => (in_array($field, $encrypted_fields) ? 1 : 0)
-                ];
+        $this->validateService($package, $vars, true);
+        if ($this->Input->errors()) {
+            return;
+        }
+
+        // Format input
+        $vars = $this->getFieldsFromInput($vars, $package);
+
+        // Only update the service if 'use_module' is true
+        if ($vars['use_module'] == 'true') {
+            // Update nameservers
+            if (isset($vars['ns']) && is_array($vars['ns'])) {
+                $this->setDomainNameservers($this->getServiceDomain($service), $row->id, $vars['ns']);
             }
         }
 
-        return $return;
+        return null;
     }
 
     /**
@@ -742,14 +837,21 @@ class Nominet extends RegistrarModule
      */
     public function renewService($package, $service, $parent_package = null, $parent_service = null)
     {
-        if (($row = $this->getModuleRow())) {
+        if (($row = $this->getModuleRowById($service->module_row_id ?? $package->module_row ?? null))) {
             // Get renew period
             $period = 1;
+            $period_unit = 'year';
             foreach ($package->pricing as $pricing) {
                 if ($pricing->id == $service->pricing_id) {
                     $period = $pricing->term;
+                    $period_unit = $pricing->period ?? 'year';
                     break;
                 }
+            }
+
+            // Nominet only supports year-based renewals
+            if ($period_unit !== 'year') {
+                return null;
             }
 
             // Only process renewal if adding years today will add time to the expiry date
@@ -760,6 +862,37 @@ class Nominet extends RegistrarModule
             $this->Input->setErrors(
                 ['module_row' => ['missing' => Language::_('Nominet.!error.module_row.missing', true)]]
             );
+        }
+
+        return null;
+    }
+
+    /**
+     * Cancels the service on the remote server. Sets Input errors on failure,
+     * preventing the service from being canceled.
+     *
+     * @param stdClass $package A stdClass object representing the current package
+     * @param stdClass $service A stdClass object representing the current service
+     * @param stdClass $parent_package A stdClass object representing the parent
+     *  service's selected package (if the current service is an addon service)
+     * @param stdClass $parent_service A stdClass object representing the parent
+     *  service of the service being canceled (if the current service is an addon service)
+     * @return mixed null to maintain the existing meta fields or a numerically
+     *  indexed array of meta fields to be stored for this service containing:
+     *  - key The key for this meta field
+     *  - value The value for this key
+     *  - encrypted Whether or not this field should be encrypted (default 0, not encrypted)
+     * @see Module::getModule()
+     * @see Module::getModuleRow()
+     */
+    public function cancelService($package, $service, $parent_package = null, $parent_service = null)
+    {
+        if (($row = $this->getModuleRowById($service->module_row_id ?? $package->module_row ?? null))) {
+            $domain = $this->getServiceDomain($service);
+
+            if ($domain) {
+                $this->deleteDomain($domain, $row->id);
+            }
         }
 
         return null;
@@ -796,7 +929,7 @@ class Nominet extends RegistrarModule
      * @param array $vars An array of user supplied info to satisfy the request
      * @return bool True if the service validates, false otherwise. Sets Input errors when false.
      */
-    public function validateService($package, array $vars = null)
+    public function validateService($package, ?array $vars = null)
     {
         $this->Input->setRules($this->getServiceRules($vars));
 
@@ -810,7 +943,7 @@ class Nominet extends RegistrarModule
      * @param array $vars An array of user-supplied info to satisfy the request
      * @return bool True if the service update validates or false otherwise. Sets Input errors when false.
      */
-    public function validateServiceEdit($service, array $vars = null)
+    public function validateServiceEdit($service, ?array $vars = null)
     {
         $this->Input->setRules($this->getServiceRules($vars, true));
 
@@ -824,7 +957,7 @@ class Nominet extends RegistrarModule
      * @param bool $edit True to get the edit rules, false for the add rules
      * @return array Service rules
      */
-    private function getServiceRules(array &$vars = null, $edit = false)
+    private function getServiceRules(?array &$vars = null, $edit = false)
     {
         // Validate the service fields
         $rules = [
@@ -1129,9 +1262,9 @@ class Nominet extends RegistrarModule
     public function tabWhois(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_whois', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1144,7 +1277,7 @@ class Nominet extends RegistrarModule
 
         // Fetch domain contacts
         try {
-            $contacts = $this->getDomainContacts($service_fields->domain, $service->module_row_id);
+            $contacts = $this->getDomainContacts($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
             $vars = [];
             foreach ($contacts as $contact) {
                 $vars[$contact->external_id] = (array) $contact;
@@ -1156,13 +1289,25 @@ class Nominet extends RegistrarModule
 
         // Update whois contact
         if (!empty($post)) {
-            $contacts = [];
-            foreach ($post as $external_id => $contact) {
-                $contact['external_id'] = $external_id;
-                $contacts[] = $contact;
+            // Validate each contact before submitting
+            $valid = true;
+            foreach ($post as $contact) {
+                if (!$this->validateContacts($contact)) {
+                    $valid = false;
+                    break;
+                }
             }
 
-            $this->setDomainContacts($service_fields->domain, $contacts, $service->module_row_id);
+            if ($valid) {
+                $contacts = [];
+                foreach ($post as $external_id => $contact) {
+                    $contact['external_id'] = $external_id;
+                    $contacts[] = $contact;
+                }
+
+                $this->setDomainContacts($service_fields->domain, $contacts, $service->module_row_id ?? $package->module_row ?? null);
+            }
+
             $vars = (object) $post;
         }
 
@@ -1197,9 +1342,9 @@ class Nominet extends RegistrarModule
     public function tabClientWhois(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_client_whois', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1212,7 +1357,7 @@ class Nominet extends RegistrarModule
 
         // Fetch domain contacts
         try {
-            $contacts = $this->getDomainContacts($service_fields->domain, $service->module_row_id);
+            $contacts = $this->getDomainContacts($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
             $vars = [];
             foreach ($contacts as $contact) {
                 $vars[$contact->external_id] = (array) $contact;
@@ -1224,13 +1369,25 @@ class Nominet extends RegistrarModule
 
         // Update whois contact
         if (!empty($post)) {
-            $contacts = [];
-            foreach ($post as $external_id => $contact) {
-                $contact['external_id'] = $external_id;
-                $contacts[] = $contact;
+            // Validate each contact before submitting
+            $valid = true;
+            foreach ($post as $contact) {
+                if (!$this->validateContacts($contact)) {
+                    $valid = false;
+                    break;
+                }
             }
 
-            $this->setDomainContacts($service_fields->domain, $contacts, $service->module_row_id);
+            if ($valid) {
+                $contacts = [];
+                foreach ($post as $external_id => $contact) {
+                    $contact['external_id'] = $external_id;
+                    $contacts[] = $contact;
+                }
+
+                $this->setDomainContacts($service_fields->domain, $contacts, $service->module_row_id ?? $package->module_row ?? null);
+            }
+
             $vars = (object) $post;
         }
 
@@ -1265,9 +1422,9 @@ class Nominet extends RegistrarModule
     public function tabNameservers(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_nameservers', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1281,7 +1438,7 @@ class Nominet extends RegistrarModule
         // Fetch domain nameservers
         $vars = (object) [];
         try {
-            $nameservers = $this->getDomainNameServers($service_fields->domain, $service->module_row_id);
+            $nameservers = $this->getDomainNameServers($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
 
             if (empty($nameservers)) {
                 $i = 1;
@@ -1310,7 +1467,7 @@ class Nominet extends RegistrarModule
                 }
             }
 
-            $this->setDomainNameservers($service_fields->domain, $service->module_row_id, $ns);
+            $this->setDomainNameservers($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $ns);
             $vars = (object) $post;
         }
 
@@ -1338,9 +1495,9 @@ class Nominet extends RegistrarModule
     public function tabClientNameservers(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_client_nameservers', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1354,7 +1511,7 @@ class Nominet extends RegistrarModule
         // Fetch domain nameservers
         $vars = (object) [];
         try {
-            $nameservers = $this->getDomainNameServers($service_fields->domain, $service->module_row_id);
+            $nameservers = $this->getDomainNameServers($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
 
             if (empty($nameservers)) {
                 $i = 1;
@@ -1383,7 +1540,7 @@ class Nominet extends RegistrarModule
                 }
             }
 
-            $this->setDomainNameservers($service_fields->domain, $service->module_row_id, $ns);
+            $this->setDomainNameservers($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $ns);
             $vars = (object) $post;
         }
 
@@ -1411,9 +1568,9 @@ class Nominet extends RegistrarModule
     public function tabDnssec(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_dnssec', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1427,19 +1584,19 @@ class Nominet extends RegistrarModule
         // Fetch domain DNSSEC
         $dnssec = [];
         try {
-            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id);
+            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
         } catch (Throwable $e) {
             $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
         }
 
         // Delete exist record
         if (!empty($post) && (($post['action'] ?? 'add') == 'delete')) {
-            $this->deleteDnssec($service_fields->domain, $service->module_row_id, $post);
+            $this->deleteDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
         }
 
         // Add new record
         if (!empty($post) && (($post['action'] ?? 'add') !== 'delete')) {
-            $this->addDnssec($service_fields->domain, $service->module_row_id, $post);
+            $this->addDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
             $vars = (object) $post;
         }
 
@@ -1470,9 +1627,9 @@ class Nominet extends RegistrarModule
     public function tabClientDnssec(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_client_dnssec', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1486,19 +1643,19 @@ class Nominet extends RegistrarModule
         // Fetch domain DNSSEC
         $dnssec = [];
         try {
-            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id);
+            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
         } catch (Throwable $e) {
             $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
         }
 
         // Delete exist record
-        if (!empty($post) && ($post['action'] == 'delete')) {
-            $this->deleteDnssec($service_fields->domain, $service->module_row_id, $post);
+        if (!empty($post) && (($post['action'] ?? 'add') == 'delete')) {
+            $this->deleteDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
         }
 
         // Add new record
-        if (!empty($post) && ($post['action'] !== 'delete')) {
-            $this->addDnssec($service_fields->domain, $service->module_row_id, $post);
+        if (!empty($post) && (($post['action'] ?? 'add') !== 'delete')) {
+            $this->addDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
             $vars = (object) $post;
         }
 
@@ -1529,9 +1686,9 @@ class Nominet extends RegistrarModule
     public function tabSettings(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_settings', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1547,11 +1704,11 @@ class Nominet extends RegistrarModule
 
         // Push domain
         if (!empty($post) && $ips_tag == '1') {
-            $this->pushDomain($service_fields->domain, $service->module_row_id, $post);
+            $this->pushDomain($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
         }
 
         // Get domain information
-        $domain = $this->getDomainInfo($service_fields->domain, $service->module_row_id);
+        $domain = $this->getDomainInfo($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
 
         // Determine if this service has access to epp_code
         $epp_code = $package->meta->epp_code ?? '0';
@@ -1582,9 +1739,9 @@ class Nominet extends RegistrarModule
     public function tabClientSettings(
         $package,
         $service,
-        array $get = null,
-        array $post = null,
-        array $files = null
+        ?array $get = null,
+        ?array $post = null,
+        ?array $files = null
     ) {
         $this->view = new View('tab_client_settings', 'default');
         $this->view->base_uri = $this->base_uri;
@@ -1600,11 +1757,11 @@ class Nominet extends RegistrarModule
 
         // Push domain
         if (!empty($post) && $ips_tag == '1') {
-            $this->pushDomain($service_fields->domain, $service->module_row_id, $post);
+            $this->pushDomain($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
         }
 
         // Get domain information
-        $domain = $this->getDomainInfo($service_fields->domain, $service->module_row_id);
+        $domain = $this->getDomainInfo($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
 
         // Determine if this service has access to epp_code
         $epp_code = $package->meta->epp_code ?? '0';
@@ -1631,7 +1788,7 @@ class Nominet extends RegistrarModule
      */
     public function checkAvailability($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         // Check with the EPP server if the domain is available
@@ -1675,7 +1832,7 @@ class Nominet extends RegistrarModule
      */
     public function getDomainInfo($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -1722,9 +1879,9 @@ class Nominet extends RegistrarModule
     public function getExpirationDate($service, $format = 'Y-m-d H:i:s')
     {
         $domain = $this->getServiceDomain($service);
-        $module_row_id = $service->module_row_id ?? null;
+        $module_row_id = $service->module_row_id ?? $service->package->module_row ?? null;
 
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -1762,9 +1919,9 @@ class Nominet extends RegistrarModule
     public function getRegistrationDate($service, $format = 'Y-m-d H:i:s')
     {
         $domain = $this->getServiceDomain($service);
-        $module_row_id = $service->module_row_id ?? null;
+        $module_row_id = $service->module_row_id ?? $service->package->module_row ?? null;
 
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -1824,22 +1981,18 @@ class Nominet extends RegistrarModule
     public function registerDomain($domain, $module_row_id = null, array $vars = [])
     {
         Loader::loadHelpers($this, ['Html']);
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         // Add contact
         $contact_id = null;
         if (isset($vars['contact'])) {
-            if (empty($vars['contact']['company'])) {
-                $vars['contact']['company'] = null;
-            }
-
             $contact = new Metaregistrar\EPP\eppContact(
                 new Metaregistrar\EPP\eppContactPostalInfo(
                     $this->Html->concat(' ', ($vars['contact']['first_name'] ?? ''), ($vars['contact']['last_name'] ?? '')),
                     $vars['contact']['city'] ?? '',
                     $vars['contact']['country'] ?? '',
-                    $vars['contact']['company'] ?? '',
+                    $vars['contact']['org_name'] ?? '',
                     $vars['contact']['address1'] ?? '',
                     $vars['contact']['state'] ?? '',
                     $vars['contact']['zip'] ?? '',
@@ -1852,7 +2005,12 @@ class Nominet extends RegistrarModule
             );
             $contact->setPassword($this->generatePassword());
 
-            $response = $this->request($api, new Metaregistrar\EPP\eppCreateContactRequest($contact));
+            $response = $this->request($api, new NominetEppCreateContactRequest(
+                $contact,
+                $vars['contact']['type'] ?? null,
+                $vars['contact']['trad_name'] ?? null,
+                $vars['contact']['co_no'] ?? null
+            ));
             if ($response) {
                 $contact_id = $response->getContactId();
             }
@@ -1868,17 +2026,6 @@ class Nominet extends RegistrarModule
             )
         );
         $register->setAuthorisationCode($this->generatePassword(6, 8));
-
-        // Set contact
-        $update = new NominetEppDomain($domain);
-        if ($contact_id) {
-            $update->setRegistrant($contact_id);
-        }
-
-        $this->request(
-            $api,
-            new Metaregistrar\EPP\eppUpdateDomainRequest(new Metaregistrar\EPP\eppDomain($domain), null, null, $update)
-        );
 
         // Set nameservers
         if (isset($vars['ns']) && is_array($vars['ns'])) {
@@ -1908,7 +2055,7 @@ class Nominet extends RegistrarModule
      */
     public function renewDomain($domain, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         // Renew the domain
@@ -1925,6 +2072,28 @@ class Nominet extends RegistrarModule
         }
 
         return false;
+    }
+
+    /**
+     * Delete a domain through the registrar
+     *
+     * @param string $domain The domain to delete
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @return bool True if the domain was successfully deleted, false otherwise
+     */
+    public function deleteDomain($domain, $module_row_id = null)
+    {
+        $row = $this->getModuleRowById($module_row_id);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+
+        $this->log($row->meta->username . '|eppDeleteDomainRequest', json_encode(compact('domain')), 'input', true);
+
+        $response = $this->request(
+            $api,
+            new Metaregistrar\EPP\eppDeleteDomainRequest(new Metaregistrar\EPP\eppDomain($domain))
+        );
+
+        return $response !== false;
     }
 
     /**
@@ -1961,7 +2130,7 @@ class Nominet extends RegistrarModule
      */
     private function pushDomain($domain, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
@@ -2000,7 +2169,7 @@ class Nominet extends RegistrarModule
      */
     public function getDomainContacts($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2021,7 +2190,7 @@ class Nominet extends RegistrarModule
             $row->meta->username . '|eppInfoDomainRequest',
             json_encode(compact('registrant')),
             'output',
-            !empty($contacts)
+            !empty($registrant)
         );
 
         // Format contacts
@@ -2040,9 +2209,16 @@ class Nominet extends RegistrarModule
                 $name = explode(' ', $contact->getContactName(), 2);
             }
 
+            // Read Nominet extension data (type, trad-name, co-no) from response
+            $nominet_ext = $this->parseNominetContactExtension($contact);
+
             // Format contact
             $formatted_contacts[] = (object) [
                 'external_id' => $type,
+                'org_name' => $contact->getContactCompanyname() ?? '',
+                'type' => $nominet_ext['type'] ?? '',
+                'trad_name' => $nominet_ext['trad_name'] ?? '',
+                'co_no' => $nominet_ext['co_no'] ?? '',
                 'email' => $contact->getContactEmail(),
                 'phone' => $contact->getContactVoice(),
                 'first_name' => $name[0] ?? '',
@@ -2068,7 +2244,7 @@ class Nominet extends RegistrarModule
      */
     public function getDomainIsLocked($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2105,7 +2281,7 @@ class Nominet extends RegistrarModule
      */
     public function getDomainNameServers($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2131,11 +2307,10 @@ class Nominet extends RegistrarModule
         $ns = [];
         foreach ($nameservers ?? [] as $nameserver) {
             if ($nameserver instanceof \Metaregistrar\EPP\eppHost) {
+                $ips = $nameserver->getIpAddresses();
                 $ns[] = [
                     'url' => trim($nameserver->getHostname(), '.'),
-                    'ips' => empty($nameserver->getIpAddresses())
-                        ? $nameserver->getIpAddresses()
-                        : gethostbyname($nameserver->getIpAddresses())
+                    'ips' => !empty($ips) ? $ips : []
                 ];
             }
         }
@@ -2152,7 +2327,7 @@ class Nominet extends RegistrarModule
      */
     public function lockDomain($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2245,7 +2420,7 @@ class Nominet extends RegistrarModule
     public function setDomainContacts($domain, array $vars = [], $module_row_id = null)
     {
         Loader::loadHelpers($this, ['Html']);
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
@@ -2259,24 +2434,14 @@ class Nominet extends RegistrarModule
             return false;
         }
 
-        // Set contact type
-        foreach ($vars as $key => $contact) {
-            switch ($key) {
-                case 'registrant':
-                    $contact['external_id'] = NominetEppContactHandle::CONTACT_TYPE_REGISTRANT;
-                    break;
-            }
-        }
+        // Get the existing registrant contact ID from the domain
+        $registrant = $info->getDomainRegistrant();
 
         try {
-            // Create contacts
-            foreach ($vars as &$contact) {
+            // Update contacts
+            foreach ($vars as $contact) {
                 if (empty($contact['first_name']) && empty($contact['last_name'])) {
                     continue;
-                }
-
-                if (empty($contact['company'])) {
-                    $contact['company'] = null;
                 }
 
                 $epp_contact = new Metaregistrar\EPP\eppContact(
@@ -2284,47 +2449,40 @@ class Nominet extends RegistrarModule
                         $this->Html->concat(' ', ($contact['first_name'] ?? ''), ($contact['last_name'] ?? '')),
                         $contact['city'] ?? '',
                         $contact['country'] ?? '',
-                        $contact['company'] ?? '',
+                        $contact['org_name'] ?? '',
                         $contact['address1'] ?? '',
                         $contact['state'] ?? '',
                         $contact['zip'] ?? '',
-                        ($vars['contact']['country'] ?? 'UK') == 'UK'
+                        ($contact['country'] ?? 'UK') == 'UK'
                             ? Metaregistrar\EPP\eppContact::TYPE_LOC
                             : Metaregistrar\EPP\eppContact::TYPE_INT
                     ),
                     $contact['email'] ?? '',
-                    $this->formatPhone($contact['phone'] ?? '', $contact['country'])
-                );
-                $epp_contact->setPassword($this->generatePassword());
-                $response = $api->request(new Metaregistrar\EPP\eppCreateContactRequest($epp_contact));
-
-                $this->log(
-                    $api->getUsername() . '|eppContact',
-                    json_encode($response),
-                    'output'
+                    $this->formatPhone($contact['phone'] ?? '', $contact['country'] ?? 'UK')
                 );
 
-                if ($response->getContactId()) {
-                    $contact['id'] = $response->getContactId();
+                // Update existing contact in-place with Nominet extension data
+                if (!empty($registrant)) {
+                    $response = $this->request(
+                        $api,
+                        new NominetEppUpdateContactRequest(
+                            new Metaregistrar\EPP\eppContactHandle($registrant),
+                            null,
+                            null,
+                            $epp_contact,
+                            $contact['type'] ?? null,
+                            $contact['trad_name'] ?? null,
+                            $contact['co_no'] ?? null
+                        )
+                    );
+
+                    $this->log(
+                        $api->getUsername() . '|eppUpdateContact',
+                        json_encode($response),
+                        'output'
+                    );
                 }
             }
-
-            // Set new contact ID
-            $update = new NominetEppDomain($domain);
-            if (!empty($vars)) {
-                foreach ($vars as $key => $contact) {
-                    if (empty($contact['id'])) {
-                        continue;
-                    }
-
-                    $update->setRegistrant($contact['id']);
-                }
-            }
-
-            $response = $this->request(
-                $api,
-                new Metaregistrar\EPP\eppUpdateDomainRequest(new Metaregistrar\EPP\eppDomain($domain), null, null, $update)
-            );
         } catch (Throwable $e) {
             if (isset($this->Input)) {
                 $this->Input->setErrors(['exception' => ['message' => $e->getMessage()]]);
@@ -2352,7 +2510,7 @@ class Nominet extends RegistrarModule
      */
     public function setDomainNameservers($domain, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
@@ -2415,28 +2573,69 @@ class Nominet extends RegistrarModule
      */
     public function setNameserverIps(array $vars = [], $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
-        $this->log($row->meta->username . '|eppCreateHostRequest', json_encode(compact('vars')), 'input', true);
+        $this->log($row->meta->username . '|setNameserverIps', json_encode(compact('vars')), 'input', true);
 
-        // Add nameservers
-        $ns = [];
-        if (!empty($vars)) {
-            foreach ($vars as $nameserver => $ips) {
-                $ns[] = new Metaregistrar\EPP\eppHost($nameserver, $ips);
+        foreach ($vars as $nameserver => $ips) {
+            $host = new Metaregistrar\EPP\eppHost($nameserver, $ips);
+
+            // Check if host already exists
+            try {
+                $check = $this->request($api, new Metaregistrar\EPP\eppCheckHostRequest($host));
+                $checks = $check->getCheckedHosts();
+                $host_exists = !empty($checks) && !($checks[0]['available'] ?? true);
+            } catch (Throwable $e) {
+                $host_exists = false;
             }
-        }
 
-        // Send request to the EPP server
-        foreach ($ns as $request) {
-            $response = $this->request(
-                $api,
-                new Metaregistrar\EPP\eppCreateHostRequest($request)
-            );
+            if ($host_exists) {
+                // Get current host info to determine which IPs to add/remove
+                $info = $this->request(
+                    $api,
+                    new Metaregistrar\EPP\eppInfoHostRequest(new Metaregistrar\EPP\eppHost($nameserver))
+                );
 
-            if (!$response) {
-                return false;
+                if ($info) {
+                    // Remove old IPs
+                    $remove = new Metaregistrar\EPP\eppHost($nameserver);
+                    $current_ips = $info->getHostAddresses();
+                    if (is_array($current_ips)) {
+                        foreach ($current_ips as $ip) {
+                            $remove->addIpAddress($ip);
+                        }
+                    }
+
+                    // Add new IPs
+                    $add = new Metaregistrar\EPP\eppHost($nameserver);
+                    foreach ((array) $ips as $ip) {
+                        $add->addIpAddress($ip);
+                    }
+
+                    $response = $this->request(
+                        $api,
+                        new Metaregistrar\EPP\eppUpdateHostRequest(
+                            new Metaregistrar\EPP\eppHost($nameserver),
+                            $add,
+                            $remove
+                        )
+                    );
+
+                    if (!$response) {
+                        return false;
+                    }
+                }
+            } else {
+                // Create new host
+                $response = $this->request(
+                    $api,
+                    new Metaregistrar\EPP\eppCreateHostRequest($host)
+                );
+
+                if (!$response) {
+                    return false;
+                }
             }
         }
 
@@ -2452,7 +2651,7 @@ class Nominet extends RegistrarModule
      */
     public function unlockDomain($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2483,7 +2682,7 @@ class Nominet extends RegistrarModule
      */
     public function updateEppCode($domain, $epp_code, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2521,7 +2720,7 @@ class Nominet extends RegistrarModule
      */
     private function getDnssec($domain, $module_row_id = null)
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
@@ -2562,7 +2761,7 @@ class Nominet extends RegistrarModule
      */
     private function addDnssec($domain, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppDnssecUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
@@ -2610,7 +2809,7 @@ class Nominet extends RegistrarModule
      */
     private function deleteDnssec($domain, $module_row_id = null, array $vars = [])
     {
-        $row = $this->getModuleRow($module_row_id);
+        $row = $this->getModuleRowById($module_row_id);
         $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
 
         $this->log($row->meta->username . '|eppDnssecUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
@@ -2690,6 +2889,319 @@ class Nominet extends RegistrarModule
     }
 
     /**
+     * Deletes a contact from the registry
+     *
+     * @param string $contact_id The contact ID to delete
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @return bool True if the contact was successfully deleted, false otherwise
+     */
+    public function deleteContact($contact_id, $module_row_id = null)
+    {
+        $row = $this->getModuleRowById($module_row_id);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+
+        $this->log($row->meta->username . '|eppDeleteContactRequest', json_encode(compact('contact_id')), 'input', true);
+
+        $response = $this->request(
+            $api,
+            new Metaregistrar\EPP\eppDeleteContactRequest(new Metaregistrar\EPP\eppContactHandle($contact_id))
+        );
+
+        return $response !== false;
+    }
+
+    /**
+     * Processes pending messages from the EPP message queue
+     *
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @return array An array of processed messages
+     */
+    public function pollMessages($module_row_id = null, $max_messages = 100)
+    {
+        $row = $this->getModuleRowById($module_row_id);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+
+        $messages = [];
+
+        try {
+            $poll = new Metaregistrar\EPP\eppPollRequest(Metaregistrar\EPP\eppPollRequest::POLL_REQ);
+            $response = $this->request($api, $poll);
+
+            while ($response && $response->getResultCode() == 1301 && count($messages) < $max_messages) {
+                $message_id = $response->getMessageId();
+                $message_data = [
+                    'id' => $message_id,
+                    'count' => $response->getMessageCount(),
+                    'message' => $response->getMessage(),
+                    'date' => $response->getMessageDate(),
+                    'type' => null,
+                    'domains' => [],
+                    'data' => []
+                ];
+
+                // Parse Nominet-specific notification data
+                if ($response instanceof NominetEppPollResponse) {
+                    $message_data['type'] = $response->getNominetMessageType();
+                    $message_data = $this->parsePollNotification($response, $message_data);
+                }
+
+                $messages[] = $message_data;
+
+                // Acknowledge the message
+                $ack = new Metaregistrar\EPP\eppPollRequest(Metaregistrar\EPP\eppPollRequest::POLL_ACK, $message_id);
+                $this->request($api, $ack);
+
+                // Check for more messages
+                $poll = new Metaregistrar\EPP\eppPollRequest(Metaregistrar\EPP\eppPollRequest::POLL_REQ);
+                $response = $this->request($api, $poll);
+            }
+        } catch (Throwable $e) {
+            $this->log(
+                $row->meta->username . '|eppPollRequest',
+                json_encode(['exception' => $e->getMessage()]),
+                'output'
+            );
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Parse Nominet notification data from a poll response
+     *
+     * @param NominetEppPollResponse $response The poll response
+     * @param array $message_data The message data array to populate
+     * @return array The enriched message data
+     */
+    private function parsePollNotification(NominetEppPollResponse $response, array $message_data)
+    {
+        switch ($message_data['type']) {
+            case NominetEppPollResponse::TYPE_DOMAIN_CANCELLED:
+                $message_data['domains'] = array_filter([$response->getCancelledDomainName()]);
+                $message_data['data'] = [
+                    'originator' => $response->getCancellationOriginator()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_DOMAINS_RELEASED:
+                $message_data['domains'] = $response->getReleasedDomainNames();
+                $message_data['data'] = [
+                    'account_id' => $response->getReleasedAccountId(),
+                    'account_moved' => $response->getReleasedAccountMoved(),
+                    'from_tag' => $response->getReleasedFromTag(),
+                    'to_tag' => $response->getReleasedToTag()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_REGISTRAR_CHANGE:
+                $message_data['domains'] = $response->getRegistrarChangeDomainNames();
+                $message_data['data'] = [
+                    'originator' => $response->getRegistrarChangeOriginator(),
+                    'registrar_tag' => $response->getRegistrarChangeTag(),
+                    'case_id' => $response->getRegistrarChangeCaseId()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_REFERRAL_REJECTED:
+                $message_data['domains'] = array_filter([$response->getRejectedDomainName()]);
+                $message_data['data'] = [
+                    'reason' => $response->getRejectionReason()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_REGISTRANT_TRANSFER:
+                $message_data['domains'] = $response->getRegistrantTransferDomainNames();
+                $message_data['data'] = [
+                    'originator' => $response->getRegistrantTransferOriginator(),
+                    'account_id' => $response->getRegistrantTransferAccountId(),
+                    'old_account_id' => $response->getRegistrantTransferOldAccountId()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_DATA_QUALITY:
+                $message_data['domains'] = $response->getDataQualityDomainNames();
+                $message_data['data'] = [
+                    'stage' => $response->getDataQualityStage(),
+                    'process_type' => $response->getDataQualityProcessType(),
+                    'suspend_date' => $response->getDataQualitySuspendDate()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_DOMAINS_SUSPENDED:
+                $message_data['domains'] = $response->getSuspendedDomainNames();
+                $message_data['data'] = [
+                    'reason' => $response->getSuspensionReason(),
+                    'cancel_date' => $response->getSuspensionCancelDate()
+                ];
+                break;
+
+            case NominetEppPollResponse::TYPE_REFERRAL_ACCEPTED:
+                $message_data['domains'] = array_filter([$response->getAcceptedDomainName()]);
+                $message_data['data'] = [
+                    'creation_date' => $response->getAcceptedCreationDate(),
+                    'expiration_date' => $response->getAcceptedExpirationDate()
+                ];
+                break;
+        }
+
+        return $message_data;
+    }
+
+    /**
+     * Returns the cron task definitions for this module.
+     *
+     * @return array An array of cron task definitions
+     */
+    private function getCronTasks()
+    {
+        return [
+            [
+                'key' => 'process_poll',
+                'task_type' => 'module',
+                'dir' => 'nominet',
+                'name' => Language::_('Nominet.getCronTasks.process_poll_name', true),
+                'description' => Language::_('Nominet.getCronTasks.process_poll_desc', true),
+                'type' => 'interval',
+                'type_value' => 15,
+                'enabled' => 1
+            ]
+        ];
+    }
+
+    /**
+     * Registers cron tasks with Blesta's CronTasks model.
+     *
+     * @param array $tasks An array of cron task definitions
+     */
+    private function addCronTasks(array $tasks)
+    {
+        Loader::loadModels($this, ['CronTasks']);
+
+        foreach ($tasks as $task) {
+            $task_id = $this->CronTasks->add($task);
+
+            if (!$task_id) {
+                $cron_task = $this->CronTasks->getByKey($task['key'], $task['dir'], $task['task_type']);
+                if ($cron_task) {
+                    $task_id = $cron_task->id;
+                }
+            }
+
+            if ($task_id) {
+                $task_vars = ['enabled' => $task['enabled']];
+                if ($task['type'] === 'time') {
+                    $task_vars['time'] = $task['type_value'];
+                } else {
+                    $task_vars['interval'] = $task['type_value'];
+                }
+
+                $this->CronTasks->addTaskRun($task_id, $task_vars);
+            }
+        }
+    }
+
+    /**
+     * Parses Nominet contact extension data (type, trad-name, co-no) from
+     * an EPP contact:info response.
+     *
+     * @param \Metaregistrar\EPP\eppInfoContactResponse $response The contact info response
+     * @return array Associative array with keys: type, trad_name, co_no
+     */
+    private function parseNominetContactExtension($response)
+    {
+        $data = ['type' => '', 'trad_name' => '', 'co_no' => ''];
+        $ns = 'http://www.nominet.org.uk/epp/xml/contact-nom-ext-1.0';
+
+        $nodes = $response->getElementsByTagNameNS($ns, 'infData');
+        if ($nodes->length === 0) {
+            return $data;
+        }
+
+        $infData = $nodes->item(0);
+
+        $typeNodes = $infData->getElementsByTagNameNS($ns, 'type');
+        if ($typeNodes->length > 0) {
+            $data['type'] = $typeNodes->item(0)->textContent;
+        }
+
+        $tradNodes = $infData->getElementsByTagNameNS($ns, 'trad-name');
+        if ($tradNodes->length > 0) {
+            $data['trad_name'] = $tradNodes->item(0)->textContent;
+        }
+
+        $coNodes = $infData->getElementsByTagNameNS($ns, 'co-no');
+        if ($coNodes->length > 0) {
+            $data['co_no'] = $coNodes->item(0)->textContent;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Validates contact fields for a registrant update.
+     *
+     * @param array $contact The contact data to validate
+     * @return bool True if valid, false otherwise. Sets Input errors on failure.
+     */
+    private function validateContacts(array $contact)
+    {
+        $rules = [
+            'first_name' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.first_name.empty', true)
+                ]
+            ],
+            'last_name' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.last_name.empty', true)
+                ]
+            ],
+            'email' => [
+                'valid' => [
+                    'rule' => 'isEmail',
+                    'message' => Language::_('Nominet.!error.contact.email.valid', true)
+                ]
+            ],
+            'phone' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.phone.empty', true)
+                ]
+            ],
+            'address1' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.address1.empty', true)
+                ]
+            ],
+            'city' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.city.empty', true)
+                ]
+            ],
+            'country' => [
+                'empty' => [
+                    'rule' => 'isEmpty',
+                    'negate' => true,
+                    'message' => Language::_('Nominet.!error.contact.country.empty', true)
+                ]
+            ]
+        ];
+
+        $this->Input->setRules($rules);
+
+        return $this->Input->validates($contact);
+    }
+
+    /**
      * Formats a phone number into +NNN.NNNNNNNNNN
      *
      * @param string $number The phone number
@@ -2717,6 +3229,44 @@ class Nominet extends RegistrarModule
     }
 
     /**
+     * Fetches a module row by ID with a fallback for contexts where $this->module
+     * may not be set (e.g. client-side tab rendering), which causes the base class
+     * getModuleRow() to return false despite the row existing.
+     *
+     * @param int|null $module_row_id The module row ID
+     * @return stdClass|false The module row object, or false if not found
+     */
+    private function getModuleRowById($module_row_id = null)
+    {
+        // Try the base class method first (checks module_id ownership).
+        // Wrapped in try/catch because in some contexts $this->module may
+        // be null, and the base class accesses $this->module->id which
+        // throws a TypeError in PHP 8+.
+        try {
+            $row = $this->getModuleRow($module_row_id);
+        } catch (\Throwable $e) {
+            $row = false;
+        }
+
+        if (!$row && $module_row_id) {
+            if (!isset($this->ModuleManager)) {
+                Loader::loadModels($this, ['ModuleManager']);
+            }
+            $row = $this->ModuleManager->getRow($module_row_id);
+        }
+
+        // Final fallback: use the first available module row.
+        // Handles client context where both $service->module_row_id and
+        // $package->module_row may be null.
+        if (!$row) {
+            $rows = $this->getModuleRows();
+            $row = !empty($rows) ? $rows[0] : null;
+        }
+
+        return $row;
+    }
+
+    /**
      * Initializes the Nominet EPP server and returns an instance of the connection.
      *
      * @param string $password The Nominet password
@@ -2727,19 +3277,34 @@ class Nominet extends RegistrarModule
      */
     private function getApi($username, $password, $secure = 'false', $sandbox = 'false')
     {
+        if (empty($username)) {
+            throw new \RuntimeException(
+                'EPP credentials not available. The Nominet module row may not be properly linked. '
+                . 'Re-save the account under Settings > Modules > Nominet.'
+            );
+        }
+
+        // Return cached connection if available
+        if (isset($this->api_connections[$username])) {
+            return $this->api_connections[$username];
+        }
+
         Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'epp_connection.php');
         Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'epp_domain.php');
         Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'epp_domain_request.php');
-        Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'epp_contact_handler.php');
+        Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'epp_contact_handle.php');
+        Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'nominet_epp_create_contact_request.php');
+        Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'nominet_epp_update_contact_request.php');
+        Loader::load(dirname(__FILE__) . DS . 'lib' . DS . 'nominet_epp_poll_response.php');
 
         $connection = new NominetEppConnection();
 
-        // Set Hostname
-        $hostname = $this->endpoint[($sandbox == 'true' ? 'sandbox' : 'live')][($secure == 'true' ? 'secure' : 'insecure')]['server'];
-        $connection->setHostname(($secure == 'true' ? 'ssl://' : '') . $hostname);
+        // Nominet requires SSL/TLS on port 700 for all environments
+        $env = $sandbox == 'true' ? 'sandbox' : 'live';
+        $hostname = $this->endpoint[$env]['server'];
+        $port = $this->endpoint[$env]['port'];
 
-        // Set port
-        $port = $this->endpoint[($sandbox == 'true' ? 'sandbox' : 'live')][($secure == 'true' ? 'secure' : 'insecure')]['port'];
+        $connection->setHostname('ssl://' . $hostname);
         $connection->setPort($port);
 
         // Set credentials
@@ -2747,21 +3312,41 @@ class Nominet extends RegistrarModule
         $connection->setPassword($password);
 
         // Login to server
-        $this->log($username . '|login', json_encode(compact('hostname', 'username', 'port', 'secure')), 'input', true);
+        $this->log($username . '|login', json_encode(compact('hostname', 'username', 'port')), 'input', true);
 
         try {
-            $connection->login();
+            if (!$connection->login()) {
+                throw new \RuntimeException('Login failed or connection could not be established');
+            }
         } catch (Throwable $e) {
             if (isset($this->Input)) {
                 $this->Input->setErrors(['exception' => ['message' => $e->getMessage()]]);
             }
             $this->log($username . '|login', json_encode(['exception' => $e->getMessage()]), 'output', false);
 
-            return new NominetEppConnection();
+            throw new \RuntimeException('Failed to connect to Nominet EPP server: ' . $e->getMessage(), 0, $e);
         }
 
         $this->log($username . '|login', json_encode($connection), 'output', true);
 
+        // Cache the connection
+        $this->api_connections[$username] = $connection;
+
         return $connection;
+    }
+
+    /**
+     * Cleanly logout from all EPP connections on destruction
+     */
+    public function __destruct()
+    {
+        foreach ($this->api_connections as $username => $connection) {
+            try {
+                $connection->logout();
+            } catch (Throwable $e) {
+                // Silently ignore logout errors during cleanup
+            }
+        }
+        $this->api_connections = [];
     }
 }

--- a/nominet.php
+++ b/nominet.php
@@ -2702,7 +2702,18 @@ class Nominet extends RegistrarModule
             Loader::loadModels($this, ['Contacts']);
         }
 
-        return $this->Contacts->intlNumber($number, $country, '.');
+        // Strip non-digit characters except + and .
+        $number = preg_replace('/[^0-9+.]/', '', $number ?? '');
+
+        // Strip trunk prefix (leading 0) for local numbers before internationalizing
+        if ($number !== '' && $number[0] !== '+') {
+            $number = ltrim($number, '0');
+        }
+
+        $formatted = $this->Contacts->intlNumber($number, $country, '.');
+
+        // Ensure no duplicate + prefix
+        return preg_replace('/^\++/', '+', $formatted);
     }
 
     /**

--- a/nominet.php
+++ b/nominet.php
@@ -1571,14 +1571,6 @@ class Nominet extends RegistrarModule
         // Get service fields
         $service_fields = $this->serviceFieldsToObject($service->fields);
 
-        // Fetch domain DNSSEC
-        $dnssec = [];
-        try {
-            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
-        } catch (Throwable $e) {
-            $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
-        }
-
         // Delete exist record
         if (!empty($post) && (($post['action'] ?? 'add') == 'delete')) {
             $this->deleteDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
@@ -1588,6 +1580,14 @@ class Nominet extends RegistrarModule
         if (!empty($post) && (($post['action'] ?? 'add') !== 'delete')) {
             $this->addDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
             $vars = (object) $post;
+        }
+
+        // Fetch domain DNSSEC after any modifications
+        $dnssec = [];
+        try {
+            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
+        } catch (Throwable $e) {
+            $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
         }
 
         $this->view->set('service_fields', $service_fields);
@@ -1630,14 +1630,6 @@ class Nominet extends RegistrarModule
         // Get service fields
         $service_fields = $this->serviceFieldsToObject($service->fields);
 
-        // Fetch domain DNSSEC
-        $dnssec = [];
-        try {
-            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
-        } catch (Throwable $e) {
-            $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
-        }
-
         // Delete exist record
         if (!empty($post) && (($post['action'] ?? 'add') == 'delete')) {
             $this->deleteDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
@@ -1647,6 +1639,14 @@ class Nominet extends RegistrarModule
         if (!empty($post) && (($post['action'] ?? 'add') !== 'delete')) {
             $this->addDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null, $post);
             $vars = (object) $post;
+        }
+
+        // Fetch domain DNSSEC after any modifications
+        $dnssec = [];
+        try {
+            $dnssec = $this->getDnssec($service_fields->domain, $service->module_row_id ?? $package->module_row ?? null);
+        } catch (Throwable $e) {
+            $this->Input->setErrors(['errors' => ['dnssec' => $e->getMessage()]]);
         }
 
         $this->view->set('service_fields', $service_fields);

--- a/nominet.php
+++ b/nominet.php
@@ -279,6 +279,12 @@ class Nominet extends RegistrarModule
                 }
             }
 
+            $display_name = ($vars['username'] ?? '');
+            if (($vars['sandbox'] ?? 'false') === 'true') {
+                $display_name .= ' (Sandbox)';
+            }
+            $meta[] = ['key' => 'display_name', 'value' => $display_name, 'encrypted' => 0];
+
             return $meta;
         }
     }
@@ -324,6 +330,12 @@ class Nominet extends RegistrarModule
                     ];
                 }
             }
+
+            $display_name = ($vars['username'] ?? '');
+            if (($vars['sandbox'] ?? 'false') === 'true') {
+                $display_name .= ' (Sandbox)';
+            }
+            $meta[] = ['key' => 'display_name', 'value' => $display_name, 'encrypted' => 0];
 
             return $meta;
         }

--- a/nominet.php
+++ b/nominet.php
@@ -19,11 +19,11 @@ class Nominet extends RegistrarModule
     private $api_connections = [];
 
     /**
-     * @var array An array containing the EPP servers for live and sandbox requests
+     * @var array An array containing the EPP servers for live and testbed requests
      */
     private $endpoint = [
         'live' => ['server' => 'epp.nominet.org.uk', 'port' => 700],
-        'sandbox' => ['server' => 'testbed-epp.nominet.org.uk', 'port' => 700]
+        'testbed' => ['server' => 'testbed-epp.nominet.org.uk', 'port' => 700]
     ];
 
     /**
@@ -188,7 +188,7 @@ class Nominet extends RegistrarModule
 
         if (!empty($vars)) {
             // Set unset checkboxes
-            $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
+            $checkbox_fields = ['secure', 'testbed', 'poll_enabled'];
 
             foreach ($checkbox_fields as $checkbox_field) {
                 if (!isset($vars[$checkbox_field])) {
@@ -224,7 +224,7 @@ class Nominet extends RegistrarModule
             $vars = $module_row->meta;
         } else {
             // Set unset checkboxes
-            $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
+            $checkbox_fields = ['secure', 'testbed', 'poll_enabled'];
 
             foreach ($checkbox_fields as $checkbox_field) {
                 if (!isset($vars[$checkbox_field])) {
@@ -251,11 +251,11 @@ class Nominet extends RegistrarModule
      */
     public function addModuleRow(array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'sandbox', 'poll_enabled'];
+        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
-        $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
+        $checkbox_fields = ['secure', 'testbed', 'poll_enabled'];
 
         foreach ($checkbox_fields as $checkbox_field) {
             if (!isset($vars[$checkbox_field])) {
@@ -280,8 +280,8 @@ class Nominet extends RegistrarModule
             }
 
             $display_name = ($vars['username'] ?? '');
-            if (($vars['sandbox'] ?? 'false') === 'true') {
-                $display_name .= ' (Sandbox)';
+            if (($vars['testbed'] ?? 'false') === 'true') {
+                $display_name .= ' (Testbed)';
             }
             $meta[] = ['key' => 'display_name', 'value' => $display_name, 'encrypted' => 0];
 
@@ -303,11 +303,11 @@ class Nominet extends RegistrarModule
      */
     public function editModuleRow($module_row, array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'sandbox', 'poll_enabled'];
+        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
-        $checkbox_fields = ['secure', 'sandbox', 'poll_enabled'];
+        $checkbox_fields = ['secure', 'testbed', 'poll_enabled'];
 
         foreach ($checkbox_fields as $checkbox_field) {
             if (!isset($vars[$checkbox_field])) {
@@ -332,8 +332,8 @@ class Nominet extends RegistrarModule
             }
 
             $display_name = ($vars['username'] ?? '');
-            if (($vars['sandbox'] ?? 'false') === 'true') {
-                $display_name .= ' (Sandbox)';
+            if (($vars['testbed'] ?? 'false') === 'true') {
+                $display_name .= ' (Testbed)';
             }
             $meta[] = ['key' => 'display_name', 'value' => $display_name, 'encrypted' => 0];
 
@@ -368,7 +368,7 @@ class Nominet extends RegistrarModule
                         [$this, 'validateConnection'],
                         $vars['username'],
                         $vars['secure'],
-                        $vars['sandbox']
+                        $vars['testbed']
                     ],
                     'message' => Language::_('Nominet.!error.password.valid_connection', true)
                 ]
@@ -379,10 +379,10 @@ class Nominet extends RegistrarModule
                     'message' => Language::_('Nominet.!error.secure.format', true)
                 ]
             ],
-            'sandbox' => [
+            'testbed' => [
                 'format' => [
                     'rule' => ['in_array', ['true', 'false']],
-                    'message' => Language::_('Nominet.!error.sandbox.format', true)
+                    'message' => Language::_('Nominet.!error.testbed.format', true)
                 ]
             ],
             'poll_enabled' => [
@@ -402,13 +402,13 @@ class Nominet extends RegistrarModule
      * @param string $password The Nominet password
      * @param string $username The Nominet userbane
      * @param string $secure 'true' to use a secure connection
-     * @param string $sandbox 'true' to use the sandbox server
+     * @param string $testbed 'true' to use the testbed server
      * @return bool True if the connection is valid, false otherwise
      */
-    public function validateConnection($password, $username, $secure = 'false', $sandbox = 'false')
+    public function validateConnection($password, $username, $secure = 'false', $testbed = 'false')
     {
         try {
-            $api = $this->getApi($username, $password, $secure, $sandbox);
+            $api = $this->getApi($username, $password, $secure, $testbed);
 
             // Check with the credentials with the EPP server
             $availability = $this->request($api, new Metaregistrar\EPP\eppCheckDomainRequest(['nominet.org.uk']));
@@ -1791,7 +1791,7 @@ class Nominet extends RegistrarModule
     public function checkAvailability($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         // Check with the EPP server if the domain is available
         $availability = $this->request($api, new Metaregistrar\EPP\eppCheckDomainRequest([$domain]));
@@ -1835,7 +1835,7 @@ class Nominet extends RegistrarModule
     public function getDomainInfo($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -1884,7 +1884,7 @@ class Nominet extends RegistrarModule
         $module_row_id = $service->module_row_id ?? $service->package->module_row ?? null;
 
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -1924,7 +1924,7 @@ class Nominet extends RegistrarModule
         $module_row_id = $service->module_row_id ?? $service->package->module_row ?? null;
 
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -1984,7 +1984,7 @@ class Nominet extends RegistrarModule
     {
         Loader::loadHelpers($this, ['Html']);
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         // Add contact
         $contact_id = null;
@@ -2058,7 +2058,7 @@ class Nominet extends RegistrarModule
     public function renewDomain($domain, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         // Renew the domain
         $renew = new Metaregistrar\EPP\eppDomain($domain);
@@ -2086,7 +2086,7 @@ class Nominet extends RegistrarModule
     public function deleteDomain($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppDeleteDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2133,7 +2133,7 @@ class Nominet extends RegistrarModule
     private function pushDomain($domain, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
 
@@ -2172,7 +2172,7 @@ class Nominet extends RegistrarModule
     public function getDomainContacts($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2247,7 +2247,7 @@ class Nominet extends RegistrarModule
     public function getDomainIsLocked($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2284,7 +2284,7 @@ class Nominet extends RegistrarModule
     public function getDomainNameServers($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2330,7 +2330,7 @@ class Nominet extends RegistrarModule
     public function lockDomain($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2423,7 +2423,7 @@ class Nominet extends RegistrarModule
     {
         Loader::loadHelpers($this, ['Html']);
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
 
@@ -2513,7 +2513,7 @@ class Nominet extends RegistrarModule
     public function setDomainNameservers($domain, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
 
@@ -2576,7 +2576,7 @@ class Nominet extends RegistrarModule
     public function setNameserverIps(array $vars = [], $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|setNameserverIps', json_encode(compact('vars')), 'input', true);
 
@@ -2654,7 +2654,7 @@ class Nominet extends RegistrarModule
     public function unlockDomain($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2685,7 +2685,7 @@ class Nominet extends RegistrarModule
     public function updateEppCode($domain, $epp_code, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppUpdateDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2723,7 +2723,7 @@ class Nominet extends RegistrarModule
     private function getDnssec($domain, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppInfoDomainRequest', json_encode(compact('domain')), 'input', true);
 
@@ -2764,7 +2764,7 @@ class Nominet extends RegistrarModule
     private function addDnssec($domain, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppDnssecUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
 
@@ -2812,7 +2812,7 @@ class Nominet extends RegistrarModule
     private function deleteDnssec($domain, $module_row_id = null, array $vars = [])
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppDnssecUpdateDomainRequest', json_encode(compact('domain', 'vars')), 'input', true);
 
@@ -2900,7 +2900,7 @@ class Nominet extends RegistrarModule
     public function deleteContact($contact_id, $module_row_id = null)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $this->log($row->meta->username . '|eppDeleteContactRequest', json_encode(compact('contact_id')), 'input', true);
 
@@ -2921,7 +2921,7 @@ class Nominet extends RegistrarModule
     public function pollMessages($module_row_id = null, $max_messages = 100)
     {
         $row = $this->getModuleRowById($module_row_id);
-        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->sandbox);
+        $api = $this->getApi($row->meta->username, $row->meta->password, $row->meta->secure, $row->meta->testbed);
 
         $messages = [];
 
@@ -3274,10 +3274,10 @@ class Nominet extends RegistrarModule
      * @param string $password The Nominet password
      * @param string $username The Nominet userbane
      * @param string $secure 'true' to use a secure connection
-     * @param string $sandbox 'true' to use the sandbox server
+     * @param string $testbed 'true' to use the testbed server
      * @return NominetEppConnection The NominetApi connection to the EPP server
      */
-    private function getApi($username, $password, $secure = 'false', $sandbox = 'false')
+    private function getApi($username, $password, $secure = 'false', $testbed = 'false')
     {
         if (empty($username)) {
             throw new \RuntimeException(
@@ -3302,7 +3302,7 @@ class Nominet extends RegistrarModule
         $connection = new NominetEppConnection();
 
         // Nominet requires SSL/TLS on port 700 for all environments
-        $env = $sandbox == 'true' ? 'sandbox' : 'live';
+        $env = $testbed == 'true' ? 'testbed' : 'live';
         $hostname = $this->endpoint[$env]['server'];
         $port = $this->endpoint[$env]['port'];
 

--- a/nominet.php
+++ b/nominet.php
@@ -63,6 +63,34 @@ class Nominet extends RegistrarModule
             if (version_compare($current_version, '1.2.0', '<')) {
                 $this->addCronTasks($this->getCronTasks());
             }
+
+            if (version_compare($current_version, '1.2.1', '<')) {
+                if (!isset($this->Record)) {
+                    Loader::loadComponents($this, ['Record']);
+                }
+
+                $rows = $this->getModuleRows();
+                foreach ($rows as $row) {
+                    // Rename 'sandbox' meta key to 'testbed'
+                    $this->Record->where('module_row_id', '=', $row->id)
+                        ->where('key', '=', 'sandbox')
+                        ->update('module_row_meta', ['key' => 'testbed']);
+
+                    // Add display_name if not already present
+                    if (!isset($row->meta->display_name)) {
+                        $username = $row->meta->username ?? '';
+                        $testbed = $row->meta->sandbox ?? 'false';
+                        $display_name = $username . ($testbed === 'true' ? ' (Testbed)' : '');
+                        $this->Record->insert('module_row_meta', [
+                            'module_row_id' => $row->id,
+                            'key' => 'display_name',
+                            'value' => $display_name,
+                            'serialized' => 0,
+                            'encrypted' => 0
+                        ]);
+                    }
+                }
+            }
         }
     }
 

--- a/nominet.php
+++ b/nominet.php
@@ -279,7 +279,7 @@ class Nominet extends RegistrarModule
      */
     public function addModuleRow(array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled'];
+        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled', 'cost_price'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
@@ -331,7 +331,7 @@ class Nominet extends RegistrarModule
      */
     public function editModuleRow($module_row, array &$vars)
     {
-        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled'];
+        $meta_fields = ['username', 'password', 'secure', 'testbed', 'poll_enabled', 'cost_price'];
         $encrypted_fields = ['password'];
 
         // Set unset checkboxes
@@ -418,7 +418,13 @@ class Nominet extends RegistrarModule
                     'rule' => ['in_array', ['true', 'false']],
                     'message' => Language::_('Nominet.!error.poll_enabled.format', true)
                 ]
-            ]
+            ],
+            'cost_price' => [
+                'format' => [
+                    'rule' => ['matches', '/^\d+(\.\d{1,4})?$/'],
+                    'message' => Language::_('Nominet.!error.cost_price.format', true)
+                ]
+            ],
         ];
 
         return $rules;

--- a/nominet.php
+++ b/nominet.php
@@ -3305,7 +3305,7 @@ class Nominet extends RegistrarModule
         $this->log($username . '|login', json_encode(compact('hostname', 'username', 'port')), 'input', true);
 
         try {
-            if (!$connection->login()) {
+            if (!$connection->login(true)) {
                 throw new \RuntimeException('Login failed or connection could not be established');
             }
         } catch (Throwable $e) {

--- a/nominet.php
+++ b/nominet.php
@@ -3385,4 +3385,95 @@ class Nominet extends RegistrarModule
         }
         $this->api_connections = [];
     }
+
+    /**
+     * Get a list of the TLD prices
+     *
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @return array A list of all TLDs and their pricing
+     *    [tld => [currency => [year# => ['register' => price, 'transfer' => price, 'renew' => price]]]]
+     */
+    public function getTldPricing($module_row_id = null)
+    {
+        return $this->getFilteredTldPricing($module_row_id);
+    }
+
+    /**
+     * Get a filtered list of the TLD prices
+     *
+     * @param int $module_row_id The ID of the module row to fetch for the current module
+     * @param array $filters A list of criteria by which to filter fetched pricings including:
+     *  - tlds A list of tlds for which to fetch pricings
+     *  - currencies A list of currencies for which to fetch pricings
+     *  - terms A list of terms for which to fetch pricings
+     * @return array A list of all TLDs and their pricing
+     *    [tld => [currency => [year# => ['register' => price, 'transfer' => price, 'renew' => price]]]]
+     */
+    public function getFilteredTldPricing($module_row_id = null, $filters = [])
+    {
+        // Get cost_price from the specified row, or the first available row
+        if ($module_row_id !== null) {
+            $row = $this->getModuleRow($module_row_id);
+        } else {
+            $rows = $this->getModuleRows();
+            $row = $rows[0] ?? null;
+        }
+
+        if ($row === null) {
+            return [];
+        }
+
+        $cost_price = (float) ($row->meta->cost_price ?? 0);
+
+        if ($cost_price <= 0) {
+            return [];
+        }
+
+        Loader::loadModels($this, ['Currencies']);
+
+        $tlds = Configure::get('Nominet.tlds');
+        $currencies = $this->Currencies->getAll(Configure::get('Blesta.company_id'));
+        $pricing = [];
+
+        foreach ($tlds as $tld) {
+            if (isset($filters['tlds']) && !in_array($tld, $filters['tlds'])) {
+                continue;
+            }
+
+            $pricing[$tld] = [];
+
+            foreach ($currencies as $currency) {
+                if (isset($filters['currencies']) && !in_array($currency->code, $filters['currencies'])) {
+                    continue;
+                }
+
+                $converted = $this->Currencies->convert(
+                    $cost_price,
+                    'GBP',
+                    $currency->code,
+                    Configure::get('Blesta.company_id')
+                );
+
+                if (!$converted) {
+                    continue;
+                }
+
+                $pricing[$tld][$currency->code] = [];
+
+                foreach (range(1, 10) as $years) {
+                    if (isset($filters['terms']) && !in_array($years, $filters['terms'])) {
+                        continue;
+                    }
+
+                    $pricing[$tld][$currency->code][$years] = [
+                        'register' => $converted * $years,
+                        'transfer' => $converted * $years,
+                        'renew'    => $converted * $years,
+                    ];
+                }
+            }
+        }
+
+        return $pricing;
+    }
 }

--- a/views/default/add_row.pdt
+++ b/views/default/add_row.pdt
@@ -23,14 +23,14 @@
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('secure', 'true', ($vars->secure ?? 'false') == 'true', ['id' => 'secure']);
-                        $this->Form->label($this->_('Nominet.row_meta.secure', true), 'secure', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
+                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
                         ?>
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
-                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('poll_enabled', 'true', ($vars->poll_enabled ?? 'false') == 'true', ['id' => 'poll_enabled']);
+                        $this->Form->label($this->_('Nominet.row_meta.poll_enabled', true), 'poll_enabled', ['class' => 'inline']);
                         ?>
                     </li>
                 </ul>

--- a/views/default/add_row.pdt
+++ b/views/default/add_row.pdt
@@ -23,8 +23,8 @@
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
-                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('testbed', 'true', ($vars->testbed ?? 'false') == 'true', ['id' => 'testbed']);
+                        $this->Form->label($this->_('Nominet.row_meta.testbed', true), 'testbed', ['class' => 'inline']);
                         ?>
                     </li>
                     <li>

--- a/views/default/add_row.pdt
+++ b/views/default/add_row.pdt
@@ -33,6 +33,12 @@
                         $this->Form->label($this->_('Nominet.row_meta.poll_enabled', true), 'poll_enabled', ['class' => 'inline']);
                         ?>
                     </li>
+                    <li>
+                        <?php
+                        $this->Form->label($this->_('Nominet.row_meta.cost_price', true), 'cost_price');
+                        $this->Form->fieldText('cost_price', ($vars->cost_price ?? null), ['id' => 'cost_price', 'class' => 'block']);
+                        ?>
+                    </li>
                 </ul>
             </div>
 

--- a/views/default/edit_row.pdt
+++ b/views/default/edit_row.pdt
@@ -23,14 +23,14 @@
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('secure', 'true', ($vars->secure ?? 'false') == 'true', ['id' => 'secure']);
-                        $this->Form->label($this->_('Nominet.row_meta.secure', true), 'secure', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
+                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
                         ?>
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
-                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('poll_enabled', 'true', ($vars->poll_enabled ?? 'false') == 'true', ['id' => 'poll_enabled']);
+                        $this->Form->label($this->_('Nominet.row_meta.poll_enabled', true), 'poll_enabled', ['class' => 'inline']);
                         ?>
                     </li>
                 </ul>

--- a/views/default/edit_row.pdt
+++ b/views/default/edit_row.pdt
@@ -23,8 +23,8 @@
                     </li>
                     <li>
                         <?php
-                        $this->Form->fieldCheckbox('sandbox', 'true', ($vars->sandbox ?? 'false') == 'true', ['id' => 'sandbox']);
-                        $this->Form->label($this->_('Nominet.row_meta.sandbox', true), 'sandbox', ['class' => 'inline']);
+                        $this->Form->fieldCheckbox('testbed', 'true', ($vars->testbed ?? 'false') == 'true', ['id' => 'testbed']);
+                        $this->Form->label($this->_('Nominet.row_meta.testbed', true), 'testbed', ['class' => 'inline']);
                         ?>
                     </li>
                     <li>

--- a/views/default/edit_row.pdt
+++ b/views/default/edit_row.pdt
@@ -33,6 +33,12 @@
                         $this->Form->label($this->_('Nominet.row_meta.poll_enabled', true), 'poll_enabled', ['class' => 'inline']);
                         ?>
                     </li>
+                    <li>
+                        <?php
+                        $this->Form->label($this->_('Nominet.row_meta.cost_price', true), 'cost_price');
+                        $this->Form->fieldText('cost_price', ($vars->cost_price ?? null), ['id' => 'cost_price', 'class' => 'block']);
+                        ?>
+                    </li>
                 </ul>
             </div>
 

--- a/views/default/manage.pdt
+++ b/views/default/manage.pdt
@@ -26,7 +26,12 @@
             for ($i = 0; $i < $num_rows; $i++) {
                 ?>
             <tr<?php echo ($i % 2 == 1) ? ' class="odd_row"' : ''; ?>>
-                <td><?php echo (isset($module->rows[$i]->meta->username) ? $this->Html->safe($module->rows[$i]->meta->username) : null); ?></td>
+                <td>
+                    <?php echo (isset($module->rows[$i]->meta->username) ? $this->Html->safe($module->rows[$i]->meta->username) : null); ?>
+                    <?php if (($module->rows[$i]->meta->sandbox ?? 'false') === 'true'): ?>
+                        <span style="color:#888;font-size:0.85em;">(Sandbox)</span>
+                    <?php endif; ?>
+                </td>
                 <td class="last">
                     <a href="<?php echo $this->Html->safe($this->base_uri . 'settings/company/modules/editrow/' . (isset($module->id) ? $module->id : null) . '/' . (isset($module->rows[$i]->id) ? $module->rows[$i]->id : null) . '/'); ?>"><?php $this->_('Nominet.manage.module_rows.edit'); ?></a>
                     <?php

--- a/views/default/manage.pdt
+++ b/views/default/manage.pdt
@@ -28,8 +28,8 @@
             <tr<?php echo ($i % 2 == 1) ? ' class="odd_row"' : ''; ?>>
                 <td>
                     <?php echo (isset($module->rows[$i]->meta->username) ? $this->Html->safe($module->rows[$i]->meta->username) : null); ?>
-                    <?php if (($module->rows[$i]->meta->sandbox ?? 'false') === 'true'): ?>
-                        <span style="color:#888;font-size:0.85em;">(Sandbox)</span>
+                    <?php if (($module->rows[$i]->meta->testbed ?? 'false') === 'true'): ?>
+                        <span style="color:#888;font-size:0.85em;">(Testbed)</span>
                     <?php endif; ?>
                 </td>
                 <td class="last">


### PR DESCRIPTION
…prefix

The formatPhone method could produce invalid EPP phone numbers in two ways:
- Local numbers with trunk prefix (e.g. 03307882211) were not stripped of the leading 0, producing +44.03307882211 instead of +44.3307882211
- Depending on Blesta version, intlNumber could return a + prefixed result that got doubled to ++44.NNNN